### PR TITLE
Update cumulusci.yml

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -6,7 +6,7 @@ project:
         namespace:  ustevent
         api_version: '46.0'
     dependencies:
-        - github: 'https://github.com/SalesforceFoundation/EDA/tree/rel/1.81'
+        - github: 'https://github.com/SalesforceFoundation/EDA'
     source_format: sfdx
 
 tasks:


### PR DESCRIPTION
# Critical Changes

# Changes
Changed the EDA Github dependency path from 'https://github.com/SalesforceFoundation/EDA/tree/rel/1.81' to 'https://github.com/SalesforceFoundation/EDA' to ensure the project is pulling from the current EDA release.

# Issues Closed
