### PR TITLE
Registrant email restriction

### DIFF
--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -116,7 +116,7 @@ public with sharing class SummitEventsRegisterController {
                             Ask_Last_Name_As_Student__c, Ask_Preferred_Class_Year__c, Ask_Preferred_First_Name__c,
                             Ask_Applicant_Type__c, Location_Type__c, Location_Title__c, Location_Address__c, Location_Map_Link__c,
                             Tracking_Event_Registration__c, Ask_Date_Of_Birth__c, Event_Type__c, Contact_Creation__c, Contact_Matching_Rules__c,
-                            Ask_Third_Party_Registrant__c
+                            Ask_Third_Party_Registrant__c, Registration_Email_Restriction__c
                     FROM Summit_Events__c
                     WHERE Id = :evtInfo.evtId
                     LIMIT 1
@@ -457,8 +457,10 @@ public with sharing class SummitEventsRegisterController {
         }
         for (Schema.PicklistEntry PicklistValue : PicklistValues) {
             if (YourFieldName == 'Registrant_Third_Party_Status__c') {
-                if (eventPage.Ask_Third_Party_Registrant__c.contains(PicklistValue.getValue())) {
-                    picklists.add(new SelectOption(PicklistValue.getValue(), PicklistValue.getLabel()));
+                if (eventPage != null) {
+                    if (eventPage.Ask_Third_Party_Registrant__c.contains(PicklistValue.getValue())) {
+                        picklists.add(new SelectOption(PicklistValue.getValue(), PicklistValue.getLabel()));
+                    }
                 }
             } else {
                 picklists.add(new SelectOption(PicklistValue.getValue(), PicklistValue.getLabel()));
@@ -478,6 +480,18 @@ public with sharing class SummitEventsRegisterController {
         Pattern TAG_REGEX = Pattern.compile('\\((\\w+|\\w+\\|\\w+)\\)');
         List<String> majorCodes = new List<String>();
         Boolean progSelectionMade = true;
+
+        registrationCRUD rCRUD = new registrationCRUD();
+
+        if (String.isNotBlank(eventPage.Registration_Email_Restriction__c) && eventPage.Registration_Email_Restriction__c != 'No Limit') {
+            System.debug('GOT TO REGISTRANT EMAIL RESTRICTIONS');
+            Summit_Events_Registration__c foundRegistration = rCRUD.checkForOtherRegistrations(eventPage.Registration_Email_Restriction__c, newEvtReg.Registrant_Email__c, evtInstance.Id, eventPage.Id);
+            if (foundRegistration != null) {
+                ApexPages.Message myMsg = new ApexPages.Message(ApexPages.Severity.ERROR, 'It appears you’ve already registered for this event. Please contact the Event Host for more information.');
+                ApexPages.addMessage(myMsg);
+                return null;
+            }
+        }
 
 
         /* if (selectedPrograms.isEmpty() && String.isBlank(selectedProgramsOne) && !String.isBlank(eventPage.Academic_Program_List__c)) {
@@ -584,7 +598,6 @@ public with sharing class SummitEventsRegisterController {
         }
 
         //Create registration if event Registration does not exist
-        registrationCRUD rCRUD = new registrationCRUD();
         if (String.isBlank(evtInfo.evtRegId) || evtInfo.evtRegId == 'COMING') {
             newEvtReg.Status__c = 'Started';
             newEvtReg.Date__c = Date.valueof(evtInstance.Start_Date_Time__c);
@@ -596,7 +609,9 @@ public with sharing class SummitEventsRegisterController {
             }
             newEvtReg = rCRUD.updateRegistration(newEvtReg);
             //Update matching log with new ID
-            newEvtReg.Matching_Log__c = newEvtReg.Matching_Log__c.replaceAll('\\[\\[REGID\\]\\]', newEvtReg.Id);
+            if (String.isNotBlank(newEvtReg.Matching_Log__c)) {
+                newEvtReg.Matching_Log__c = newEvtReg.Matching_Log__c.replaceAll('\\[\\[REGID\\]\\]', newEvtReg.Id);
+            }
             evtInfo.evtRegId = newEvtReg.Id;
             //make matching log functional for reparenting
         }
@@ -629,6 +644,43 @@ public with sharing class SummitEventsRegisterController {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'HELLO: ' + ex.getMessage()));
             }
             return newEvtReg;
+        }
+
+        public Summit_Events_Registration__c checkForOtherRegistrations(String checkType, String registrationEmail, Id eventInstanceId, Id eventId) {
+
+            String[] notAcceptableStatuses = new List<String>();
+            notAcceptableStatuses.add('Cancelled');
+            notAcceptableStatuses.add('Started');
+            notAcceptableStatuses.add('Status');
+
+            List<Summit_Events_Registration__c> foundRegistrations = new List<Summit_Events_Registration__c>();
+            Summit_Events_Registration__c foundRegistration = null;
+
+            System.debug('Type: ' + checkType + ', email: ' + registrationEmail + ', Instance ID: ' + eventInstanceId + ', Event Id: ' + eventId);
+
+            if (checkType == 'One registration per instance') {
+                foundRegistrations = [
+                        SELECT Id, LastModifiedDate, Registrant_Email__c
+                        FROM Summit_Events_Registration__c
+                        WHERE Registrant_Email__c = :registrationEmail
+                        AND Event_Instance__c = :eventInstanceId
+                        AND Status__c NOT IN :notAcceptableStatuses
+                        ORDER BY LastModifiedDate
+                ];
+            } else if (checkType == 'One registration per event') {
+                foundRegistrations = [
+                        SELECT Id, LastModifiedDate, Registrant_Email__c
+                        FROM Summit_Events_Registration__c
+                        WHERE Registrant_Email__c = :registrationEmail
+                        AND Event__c = :eventId
+                        AND Status__c NOT IN :notAcceptableStatuses
+                        ORDER BY LastModifiedDate
+                ];
+            }
+            if (foundRegistrations.size() > 0) {
+                foundRegistration = foundRegistrations[0];
+            }
+            return foundRegistration;
         }
 
     }

--- a/force-app/main/default/classes/SummitEventsShared_TEST.cls
+++ b/force-app/main/default/classes/SummitEventsShared_TEST.cls
@@ -44,7 +44,7 @@ public with sharing class SummitEventsShared_TEST {
     @isTest static void testMatching2() {
         //Insert a test event
         Contact evtCon = SummitEventsTestSharedDataFactory.createContact('MatchFirst', 'Match', 'MatchLast', 'match@valleyhill.net', '55555', '(555) 555-5555', '1971-03-22', '2012');
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 2', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 2', 'Test Event', '', true, true, '');
 
         Test.startTest();
         //Add instance ID to register page
@@ -86,7 +86,7 @@ public with sharing class SummitEventsShared_TEST {
 
     @isTest static void testNoMatchGraduate() {
         //Insert a test event
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         Test.startTest();
         //Add instance ID to register page
         PageReference pageRef = Page.SummitEventsRegister;
@@ -106,7 +106,7 @@ public with sharing class SummitEventsShared_TEST {
     @isTest static void testMatching1() {
         //Insert a test event
         Contact evtCon = SummitEventsTestSharedDataFactory.createContact('MatchFirst', 'Match', 'MatchLast', 'match@valleyhill.net', '55555', '(555) 555-5555', '1971-03-22', '2012');
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'High School Senior', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'High School Senior', true, true, '');
 
         Test.startTest();
         //Add instance ID to register page
@@ -162,13 +162,31 @@ public with sharing class SummitEventsShared_TEST {
         registerCtrl.getApplicantTypeDD();
         registerCtrl.getRelationshipDD();
         registerCtrl.getProgramsAvailable();
+    }
 
+    @isTest static void testEventWithEmailRestrictions() {
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, 'One registration per instance');
+
+        Test.startTest();
+        //Add instance ID to register page
+        PageReference pageRef = Page.SummitEventsRegister;
+        Test.setCurrentPage(pageRef);
+        ApexPages.currentPage().getParameters().put('instanceID', evtInst.Id);
+        SummitEventsRegisterController registerCtrl = new SummitEventsRegisterController();
+        registerCtrl.newEvtReg = SummitEventsTestSharedDataFactory.createEventRegistrationObj('TestFirst', 'Test', 'TestLast', 'test@valleyhill.net', '55418', '(555) 444-4444', '1989-03-22', '2002');
+        registerCtrl.saveContactRegistration();
+//        UST_Event_Registration__c evtReg2 = TestUSTEventSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
+        registerCtrl.saveContactRegistration();
+        registerCtrl.newEvtReg.Registrant_Email__c = 'test2@valleyhill.net';
+        registerCtrl.newEvtReg.Registrant_Date_of_Birth__c = Date.valueOf('1989-03-22');
+        registerCtrl.saveContactRegistration();
+        Test.stopTest();
     }
 
     @isTest static void testRegAlreadyExists() {
         //Insert a test event
         Contact evtCon = SummitEventsTestSharedDataFactory.createContact('MatchFirst', 'Match', 'MatchLast', 'match@valleyhill.net', '55555', '(555) 555-5555', '1971-03-22', '2012');
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'High School Senior', false, false);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'High School Senior', false, false, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'MatchFirst', 'MatchLast', 'match@valleyhill.net', '55555', '1971-03-22', '2012', null);
 
         Test.startTest();
@@ -193,7 +211,7 @@ public with sharing class SummitEventsShared_TEST {
 
     @isTest static void testSubmit() {
         Contact evtCon = SummitEventsTestSharedDataFactory.createContact('TestFirst1', 'Test', 'TestLast1', 'test1@valleyhill.net', '55418', '(555) 555-5555', '1971-03-22', '2012');
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         Test.startTest();
         PageReference pageRef = Page.SummitEventsSubmit;
@@ -210,7 +228,7 @@ public with sharing class SummitEventsShared_TEST {
 
     @isTest static void testRegWithOptions() {
         Contact evtCon = SummitEventsTestSharedDataFactory.createContact('TestFirst1', 'Test', 'TestLast1', 'test1@valleyhill.net', '55418', '(555) 555-5555', '1971-03-22', '2012');
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         Test.startTest();
@@ -245,7 +263,7 @@ public with sharing class SummitEventsShared_TEST {
     }
 
     @isTest static void testRegCancel() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         Test.startTest();
@@ -258,7 +276,7 @@ public with sharing class SummitEventsShared_TEST {
     }
 
     @isTest static void testRegConfirmationPage() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         Test.startTest();
@@ -272,7 +290,7 @@ public with sharing class SummitEventsShared_TEST {
     }
 
     @isTest static void testParkingPass() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching Rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         evtReg.Status__c = 'Requested';
         update evtReg;
@@ -289,7 +307,7 @@ public with sharing class SummitEventsShared_TEST {
     }
 
     @isTest static void testEventFeed() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'Alumni', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', 'Alumni', true, true, '');
 
         Test.startTest();
         RestRequest req = new RestRequest();
@@ -367,7 +385,7 @@ public with sharing class SummitEventsShared_TEST {
 //    }
 
     @isTest static void testLetterheadLookup() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         Summit_Events_Email__c testEvtEmail = SummitEventsTestSharedDataFactory.createTestTransactionEmail(evtInst, 'Requested', '');
 
@@ -414,7 +432,7 @@ public with sharing class SummitEventsShared_TEST {
         hed.TDTM_Global_API.setTdtmConfig(tokens);
 
 
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         Summit_Events_Email__c testEvtEmail = SummitEventsTestSharedDataFactory.createTestTransactionEmail(evtInst, 'Started', '');
         Summit_Events_Email__c testEvtEmail2 = SummitEventsTestSharedDataFactory.createTestTransactionEmail(evtInst, 'Requested', '');
         Summit_Events_Email__c testEvtEmail3 = SummitEventsTestSharedDataFactory.createTestTransactionEmail(evtInst, 'Requested', 'On Hold');
@@ -487,7 +505,7 @@ public with sharing class SummitEventsShared_TEST {
         // Pass trigger handler config to set method for this test run
         hed.TDTM_Global_API.setTdtmConfig(tokens);
 
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         //Summit_Events_Appointments__c addingAppointment = new Summit_Events_Appointments__c(Event_Registration__c = testRegistration, Appointment_Type__c);
@@ -520,7 +538,7 @@ public with sharing class SummitEventsShared_TEST {
 
     //Test the add to calendar page
     @isTest static void testSEAddToCalendar() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true, '');
 
         Test.startTest();
         ApexPages.currentPage().getParameters().put('instanceID', evtInst.Id);
@@ -531,7 +549,7 @@ public with sharing class SummitEventsShared_TEST {
 
     //Test the add to calendar page
     @isTest static void testSEHostAssignment() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         Test.startTest();
@@ -566,7 +584,7 @@ public with sharing class SummitEventsShared_TEST {
 
     //Test the add to calendar page
     @isTest static void testSEProgramFinder() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Test Event', '', true, true, '');
         //creatTestPrograms();
         Test.startTest();
         // ApexPages.currentPage().getParameters().put('instanceID', testInstance.Id);
@@ -580,7 +598,7 @@ public with sharing class SummitEventsShared_TEST {
 
     //Test itinerary printout
     @isTest static void testItineraryPrint() {
-        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true);
+        Summit_Events_Instance__c evtInst = SummitEventsTestSharedDataFactory.createTestEvent('Matching rules 1', 'Overnight Event', '', true, true, '');
         Summit_Events_Registration__c evtReg = SummitEventsTestSharedDataFactory.createEventRegistration(evtInst, 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
 
         Test.startTest();

--- a/force-app/main/default/classes/SummitEventsTestSharedDataFactory.cls
+++ b/force-app/main/default/classes/SummitEventsTestSharedDataFactory.cls
@@ -6,11 +6,16 @@
 @isTest
 public with sharing class SummitEventsTestSharedDataFactory {
 
-    public static Summit_Events_Instance__c createTestEvent(String matchingRules, String testEventName, String audience, Boolean includeAppt, Boolean includeAddQuestions) {
+    public static Summit_Events_Instance__c createTestEvent(
+            String matchingRules,
+            String testEventName,
+            String audience,
+            Boolean includeAppt,
+            Boolean includeAddQuestions,
+            String registrationEmailRestriction
+    ) {
 
         Summit_Events__c testEvent = new Summit_Events__c();
-
-        System.Debug('|---------->> USER:' + UserInfo.getUserName());
 
         //Create event
         testEvent = new Summit_Events__c(
@@ -27,7 +32,7 @@ public with sharing class SummitEventsTestSharedDataFactory {
                 Include_Time_frame_List__c = true,
                 Allow_Other_Attendees__c = true,
                 Ask_Mailing_Address__c = 'Ask',
-                Ask_Phone__c = 'Ask',
+                Ask_Phone__c = 'Ask home and mobile require one',
                 Ask_Date_Of_Birth__c = 'Ask',
                 Max_Other_Attendees__c = 5,
                 Close_Event_Days_Before__c = 0,
@@ -37,8 +42,11 @@ public with sharing class SummitEventsTestSharedDataFactory {
                 Location_Address__c = '123 Electric Ave.',
                 Location_Type__c = 'Minneapolis',
                 Contact_Matching_Rules__c = matchingRules
-
         );
+
+        if (String.isNotBlank(registrationEmailRestriction)) {
+            testEvent.Registration_Email_Restriction__c = registrationEmailRestriction;
+        }
 
         if (includeAddQuestions) {
             testEvent.Add_Info_Question_Type_1__c = 'Pick-list';

--- a/force-app/main/default/objects/Summit_Events__c/fields/Registration_Email_Restriction__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Registration_Email_Restriction__c.field-meta.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Registration_Email_Restriction__c</fullName>
+    <description>Validates other registrations in the same event to see if the same email was used ignoring &quot;Cancelled&quot; OR &quot;Started&quot; statu registrations. Errors will be given on the application if another email is found with these circumstances.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Validates other registrations in the same event to see if the same email was used ignoring &quot;Cancelled&quot; OR &quot;Started&quot; statu registrations. Errors will be given on the application if another email is found with these circumstances.</inlineHelpText>
+    <label>Registration Email Restriction</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>No limit</fullName>
+                <default>true</default>
+                <label>No limit</label>
+            </value>
+            <value>
+                <fullName>One registration per instance</fullName>
+                <default>false</default>
+                <label>One registration per instance</label>
+            </value>
+            <value>
+                <fullName>One registration per event</fullName>
+                <default>false</default>
+                <label>One registration per event</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1417,6 +1417,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Registration_Email_Restriction__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Start_Date__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1246,6 +1246,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Registration_Email_Restriction__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Start_Date__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1319,7 +1324,7 @@
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Summit_Events_Registration__c</object>
-        <viewAllRecords>false</viewAllRecords>
+        <viewAllRecords>true</viewAllRecords>
     </objectPermissions>
     <objectPermissions>
         <allowCreate>false</allowCreate>

--- a/force-app/main/default/staticresources/SummitEventsAssets/css/main.css
+++ b/force-app/main/default/staticresources/SummitEventsAssets/css/main.css
@@ -3,10 +3,10 @@
 .slds-has-error {border-color:red!important;}
 
 
-.validationError {
+.validationError, ul[role=alert] li {
     color: red !important;
 }
-
+ul[role=alert] li { font-weight:bold}
 .validationError input {
     border: 1px solid red;
 }


### PR DESCRIPTION

# Critical Changes

- Unit tests have been updated for coverage and because they were broken due to recent field type changes.

- bug squashed that would break the option not to create a contact upon registration.

# Changes

# Issues Closed

#42 - Events can now be restricted by email so that the same email cannot sign up for an event again, or an event instance again.