### PR TITLE
Calendar fixes crown

### DIFF
--- a/force-app/main/default/classes/SummitEventsFeed.cls
+++ b/force-app/main/default/classes/SummitEventsFeed.cls
@@ -85,9 +85,21 @@ global with sharing class SummitEventsFeed {
         eventQuery += ' WHERE ';
         eventQuery += ' Event__R.Event_Status__c = \'Active\' ';
         eventQuery += ' AND Active_Status__c = \'Active\' ';
-        eventQuery += ' AND (Current_Available_Capacity__c > 0 OR Capacity__c = null) ';
         eventQuery += ' AND Event__r.Private_Event__c = false ';
         eventQuery += ' AND Private_Instance__c = false ';
+
+        Boolean hideClosed = false;
+        if (String.isNotBlank(req.params.get('hideClosed'))) {
+            try {
+                hideClosed = Boolean.valueOf(req.params.get('hideClosed'));
+            } catch (Exception e) {
+                hideClosed = false;
+            }
+        }
+        if (hideClosed) {
+            eventQuery += ' AND (Current_Available_Capacity__c > 0 OR Capacity__c = null) ';
+        }
+
 
         // build and sanitize the where statement that have variables
 
@@ -311,10 +323,13 @@ global with sharing class SummitEventsFeed {
                 evt.locationMapLink = '';
             }
 
-            if (evt.start < regDateOpenDate) {
+            if (evt.start < regDateOpenDate || eventInstance.Current_Available_Capacity__c <= 0) {
                 evt.eventClosed = true;
-                evt.eventUrl = 'javascript:void(0);';
+                evt.eventUrl = 'javascript:;';
                 evt.className = 'eventClosed';
+                if (!hideClosed) {
+                    EventList.add(evt);
+                }
             } else {
                 evt.eventClosed = false;
                 if (!String.isBlank(eventInstance.Event__r.Alternate_Registration_URL__c) || !String.isBlank(eventInstance.Alternate_Registration_URL_Override__c)) {
@@ -328,9 +343,8 @@ global with sharing class SummitEventsFeed {
                     evt.eventUrl = eventInstance.Event__r.Community_Base_URL__c + namespace + 'SummitEventsRegister?instanceID=' + eventInstance.Id;
                 }
                 evt.className = 'eventOpened';
+                EventList.add(evt);
             }
-
-            EventList.add(evt);
         }
         return EventList;
     }

--- a/force-app/main/default/pages/SummitEvents.page
+++ b/force-app/main/default/pages/SummitEvents.page
@@ -66,7 +66,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                 }
 
                 .SummitEventsItem:hover {
-                    text-decoration: none!important;
+                    text-decoration: none !important;
                 }
 
                 .fc-listMonth-view .SummitEventsItem {
@@ -87,6 +87,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     display: block;
                     font-size: .85em;
                 }
+
                 .tippy-box {
                     background: #f9f9f9;
                     font-family: 'Salesforce Sans', Arial, sans-serif;
@@ -116,6 +117,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                 const calendarEl = document.getElementById('fullCalendarView');
                 const SESettings = JSON.parse(readCookie('SummitEvents'));
                 const audienceDD = document.getElementById('audienceDD');
+                const hideCalendarUntilAudience = false;
                 if (audienceDD) {
                     loadAudienceDD();
                 }
@@ -156,15 +158,16 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     eventTextColor: '#000',
                     eventContent: function (info) {
                         let wrap = document.createElement('a');
-                        wrap.href= info.event.url;
-                        wrap.target = '_blank';
                         wrap.classList.add('SummitEventsItem');
                         let titleWrap = document.createElement('span');
                         titleWrap.classList.add('summitEventsTitle');
-                        if (info.event.url && info.classNames != 'eventClosed') {
+                        console.log(JSON.stringify(info.event.classNames));
+                        if (info.event.classNames != 'eventClosed') {
                             titleWrap.innerHTML = info.event.title
+                            wrap.href = info.event.url;
+                            wrap.target = '_blank';
                         } else {
-                            titleWrap.innerHTML = info.event.title + '<br><em>Event is closed</em>';
+                            titleWrap.innerHTML = info.event.title + '<br><em>Event is closed.</em>';
                         }
                         let descWrap = document.createElement('span');
                         descWrap.classList.add('summitEventsDesc');
@@ -175,7 +178,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         let endTime = formatTimeString(info.event.end.toLocaleString());
                         timeWrap.innerHTML = startTime + ' - ' + endTime;
                         wrap.append(titleWrap);
-                        if(info.view.type === 'dayGridMonth') {
+                        if (info.view.type === 'dayGridMonth') {
                             wrap.append(timeWrap);
                         } else {
                             wrap.append(descWrap);
@@ -202,6 +205,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     audienceDD.addEventListener('change', function () {
                         eraseCookie('SummitEvents');
                         createCookie('SummitEvents', '{"audience" : "' + getAudienceDDValue() + '"}', '');
+                        if (getAudienceDDValue() == '' && hideCalendarUntilAudience) {
+                            calendarEl.style.visibility = "hidden";
+                        } else {
+                            calendarEl.style.visibility = "visible";
+                        }
                         calendar.refetchEvents();
                     });
                 }
@@ -222,7 +230,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     if (audienceDD) {
                         audienceDDValue = audienceDD.value;
                     }
-                    if (audienceDDValue == 'Select..') {
+                    if (audienceDDValue == 'Select...') {
                         audienceDDValue = '';
                     }
                     return audienceDDValue;
@@ -241,6 +249,9 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 }
                             }
                             calendar.refetchEvents();
+                            if (getAudienceDDValue() == '' && hideCalendarUntilAudience) {
+                                calendarEl.style.visibility = "hidden";
+                            }
                         }).catch(function (error) {
                         console.log(error);
                     });

--- a/force-app/main/default/pages/SummitEvents.page
+++ b/force-app/main/default/pages/SummitEvents.page
@@ -21,9 +21,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     ** Custom Javascript to embed Salesforce feed and format it (highlighted below)
             -->
             <!-- Copy this for Summit Events Fullcalendar display on any page. Insert anywhere before code below -->
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.2.0/main.min.css"/>
-            <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.2.0/main.min.js"></script>
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.3.0/main.min.css"/>
+            <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.3.0/main.min.js"></script>
             <script src="https://cdn.jsdelivr.net/npm/moment@2.27.0/min/moment.min.js"></script>
+            <script src="https://unpkg.com/@popperjs/core@2"></script>
+            <script src="https://unpkg.com/tippy.js@6"></script>
             <!-- end copy -->
         </apex:define>
         <apex:define name="sectionNav"/>
@@ -56,19 +58,67 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
             <!-- Copy this for Summit Events Fullcalendar display on any page. paste after fullCalendarView div -->
             <style>
                 .SummitEventsItem {
-                    display: inline-block;
+                    display: block;
+                    white-space: normal;
+                    padding: 4px 2px;
+                    font-size: 1.1em;
+                    line-height: 1.4em !important;
                 }
 
-                .fc-daygrid-event {
-                    white-space: normal;
+                .SummitEventsItem:hover {
+                    text-decoration: none!important;
+                }
+
+                .fc-listMonth-view .SummitEventsItem {
+                    font-size: 1.1em;
+                    line-height: 1.4em !important;
+                }
+
+                .SummitEventsItem .eventClosed, .SummitEventsItem .eventClosed * {
+                    color: gray !important;
+                }
+
+                .SummitEventsItem .summitEventsTitle, .SummitEventItem .summitEventsDesc {
+                    display: block;
+                    margin: 0px 0px 4px 0px;
+                }
+
+                .SummitEventsItem .summitEventsTimes {
+                    display: block;
+                    font-size: .85em;
+                }
+                .tippy-box {
+                    background: #f9f9f9;
+                    font-family: 'Salesforce Sans', Arial, sans-serif;
+                    font-size: .8em;
+                    border: 1px solid #4f4f4f;
+                    color: #212121;
+                }
+
+                .tippy-box[data-placement^='top'] > .tippy-arrow::before {
+                    border-top-color: #4f4f4f;
+                }
+
+                .tippy-box[data-placement^='bottom'] > .tippy-arrow::before {
+                    border-bottom-color: #4f4f4f;
+                }
+
+                .tippy-box[data-placement^='left'] > .tippy-arrow::before {
+                    border-left-color: #4f4f4f;
+                }
+
+                .tippy-box[data-placement^='right'] > .tippy-arrow::before {
+                    border-right-color: #4f4f4f;
                 }
             </style>
             <script>
                 const feedURL = '{!feedURL}'
                 const calendarEl = document.getElementById('fullCalendarView');
                 const SESettings = JSON.parse(readCookie('SummitEvents'));
-                let audience;
-                loadAudienceDD();
+                const audienceDD = document.getElementById('audienceDD');
+                if (audienceDD) {
+                    loadAudienceDD();
+                }
 
                 function getCalView() {
                     let initialView = 'dayGridMonth';
@@ -81,12 +131,13 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                 let calendar = new FullCalendar.Calendar(calendarEl, {
                     initialView: getCalView(),
                     handleWindowResize: true,
+                    textColor: '#000',
                     events: {
                         url: feedURL,
                         extraParams: function () {
                             return {
                                 'feedType': 'eventList',
-                                'audience': document.getElementById("audienceDD").value
+                                'audience': getAudienceDDValue()
                             }
                         },
                     },
@@ -95,62 +146,86 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                             id: rawEventData.Id,
                             title: rawEventData.title,
                             url: rawEventData.eventUrl,
-                            start: rawEventData.start.replace('Z',''),
-                            end: rawEventData.end.replace('Z',''),
+                            start: rawEventData.start.replace('Z', ''),
+                            end: rawEventData.end.replace('Z', ''),
                             description: rawEventData.description,
                             className: rawEventData.className,
                         };
                     },
                     eventDisplay: 'auto',
                     eventTextColor: '#000',
-                    windowResize: function (arg) {
-                        this.view.type = getCalView();
-                    },
-                    eventClick: function (info) {
-                        info.jsEvent.preventDefault();
-                        if (info.event.url) {
-                            window.open(info.event.url);
-                        }
-                    },
                     eventContent: function (info) {
-                        let audience = document.getElementById("audienceDD").value;
-                        let wrap = document.createElement('div');
-                        //alert(info.event.className);
-                        wrap.classList.add(info.event.className);
-                        let link = document.createElement('a');
-                        link.href = info.event.url + '&audience=' + audience;
-                        link.target = '_blank';
-                        let desc = info.event.title;
-                        let startTime = formatTimeString(info.event.start.toLocaleTimeString());
-                        let endTime = formatTimeString(info.event.end.toLocaleTimeString());
-                        desc += '<br/>' + startTime + ' - ' + endTime;
-                        link.innerHTML = desc;
-                        wrap.append(link);
+                        let wrap = document.createElement('a');
+                        wrap.href= info.event.url;
+                        wrap.target = '_blank';
+                        wrap.classList.add('SummitEventsItem');
+                        let titleWrap = document.createElement('span');
+                        titleWrap.classList.add('summitEventsTitle');
+                        if (info.event.url && info.classNames != 'eventClosed') {
+                            titleWrap.innerHTML = info.event.title
+                        } else {
+                            titleWrap.innerHTML = info.event.title + '<br><em>Event is closed</em>';
+                        }
+                        let descWrap = document.createElement('span');
+                        descWrap.classList.add('summitEventsDesc');
+                        descWrap.innerHTML = info.event.extendedProps.description;
+                        let timeWrap = document.createElement('span');
+                        timeWrap.classList.add('summitEventsTimes');
+                        let startTime = formatTimeString(info.event.start.toLocaleString());
+                        let endTime = formatTimeString(info.event.end.toLocaleString());
+                        timeWrap.innerHTML = startTime + ' - ' + endTime;
+                        wrap.append(titleWrap);
+                        if(info.view.type === 'dayGridMonth') {
+                            wrap.append(timeWrap);
+                        } else {
+                            wrap.append(descWrap);
+                        }
                         let arrayOfDomNodes = [wrap]
                         return {domNodes: arrayOfDomNodes}
+                    },
+                    eventMouseEnter: function (info) {
+                        let desc = info.event.extendedProps.description;
+                        tippy(info.el, {
+                            animate: 'fade',
+                            content: desc
+                        });
+                    },
+                    windowResize: function (arg) {
+                        this.changeView(getCalView());
+                        this.refetchEvents();
                     }
                 });
 
                 calendar.render();
 
-                document.getElementById("audienceDD").addEventListener('change', function () {
-                    eraseCookie('SummitEvents');
-                    createCookie('SummitEvents', '{"audience" : "' + $(this).val() + '"}', '');
-                    calendar.refetchEvents();
-                });
-
-                function setInstanceCookie(instanceID) {
-                    eraseCookie('SummitEvents');
-                    createCookie('SummitEvents', '{"audience" : "' + $("#audienceDD").val() + '", "instanceID" : "' + instanceID + '" }', '');
-                    return true;
+                if (audienceDD) {
+                    audienceDD.addEventListener('change', function () {
+                        eraseCookie('SummitEvents');
+                        createCookie('SummitEvents', '{"audience" : "' + getAudienceDDValue() + '"}', '');
+                        calendar.refetchEvents();
+                    });
                 }
 
                 function formatTimeString(stringIn) {
                     let stringOut = '';
+                    stringIn = stringIn.split(',');
+                    stringIn = stringIn[stringIn.length - 1];
+                    let first = stringIn.indexOf(',');
                     let last = stringIn.lastIndexOf(":");
                     stringOut = stringIn.substring(stringIn, last);
                     stringOut += stringIn.substring(last + 3, stringIn.length);
                     return stringOut;
+                }
+
+                function getAudienceDDValue() {
+                    let audienceDDValue = '';
+                    if (audienceDD) {
+                        audienceDDValue = audienceDD.value;
+                    }
+                    if (audienceDDValue == 'Select..') {
+                        audienceDDValue = '';
+                    }
+                    return audienceDDValue;
                 }
 
                 function loadAudienceDD() {
@@ -158,11 +233,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         feedURL + "?feedType=audienceDD"
                     ).then((resp) => resp.json())
                         .then(function (data) {
-                            populateOptions(data, document.getElementById("audienceDD"))
+                            populateOptions(data, audienceDD)
                             //preselect audience based on cookie
                             if (SESettings != null) {
                                 if (SESettings.audience != null) {
-                                    document.getElementById("audienceDD").value = SESettings.audience;
+                                    audienceDD.value = SESettings.audience;
                                 }
                             }
                             calendar.refetchEvents();
@@ -187,7 +262,6 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
                 function createCookie(name, value, days) {
                     let expires;
-
                     if (days) {
                         let date = new Date();
                         date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));


### PR DESCRIPTION

# Critical Changes

# Changes
- Event Feed now shows closed events
- Event feed accepts hideClose=true/false url parameter
- Tippy tooltip added as third party cdn script on calendar page on SummitEvents.page
- Closed events are properly noted on SummitEvents.page calendar
- Responsive calendar view works on resize on SummitEvents.page calendar
- Script on SummitEvents.page calendar has variable hideCalendarUntilAudience=true/false to not show calendar until an audience is selected. Set to false on page but usable by others using the same script on their Web sites
- Event bounds on calendar now allow wrapping better to not overflow text box on SummitEvents.page calendar

# Issues Closed
