### PR TITLE
Text updates, field value increase, dynamic display update

### DIFF
--- a/force-app/main/default/objects/Summit_Events_Instance__c/fields/Capacity__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Instance__c/fields/Capacity__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText>Capacity of this Event Instance</inlineHelpText>
     <label>Capacity</label>
-    <precision>3</precision>
+    <precision>5</precision>
     <required>false</required>
     <scale>0</scale>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events_Instance__c/fields/Instance_Short_Description__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Instance__c/fields/Instance_Short_Description__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Instance_Short_Description__c</fullName>
     <description>Short qualifying description of session.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Short qualifying description of session.</inlineHelpText>
+    <inlineHelpText>Short qualifying description of session. Appears on hover over on the calendar.</inlineHelpText>
     <label>Instance Short Description</label>
     <length>255</length>
     <required>false</required>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Applicant_Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Applicant_Type__c.field-meta.xml
@@ -14,7 +14,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Date_Of_Birth__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Date_Of_Birth__c.field-meta.xml
@@ -14,7 +14,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Gender__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Gender__c.field-meta.xml
@@ -14,7 +14,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Last_Name_As_Student__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Last_Name_As_Student__c.field-meta.xml
@@ -13,7 +13,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Mailing_Address__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Mailing_Address__c.field-meta.xml
@@ -14,7 +14,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Phone__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Phone__c.field-meta.xml
@@ -15,7 +15,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Preferred_Class_Year__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Preferred_Class_Year__c.field-meta.xml
@@ -15,7 +15,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Preferred_First_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Preferred_First_Name__c.field-meta.xml
@@ -13,7 +13,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Pronoun__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Pronoun__c.field-meta.xml
@@ -14,7 +14,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Registrant_Program_Of_Interest__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Registrant_Program_Of_Interest__c.field-meta.xml
@@ -15,7 +15,7 @@
             <sorted>false</sorted>
             <value>
                 <fullName>Do not ask</fullName>
-                <default>false</default>
+                <default>true</default>
                 <label>Do not ask</label>
             </value>
             <value>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Third_Party_Registrant__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Third_Party_Registrant__c.field-meta.xml
@@ -2,6 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Ask_Third_Party_Registrant__c</fullName>
     <externalId>false</externalId>
+    <inlineHelpText>Capture information if the person registering is not the registrant. For additional values, add matchiing values to picklist on registration as well as this field</inlineHelpText>
     <label>Ask Third Party Registrant</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Building__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Building__c.field-meta.xml
@@ -10,7 +10,7 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <restricted>false</restricted>
+        <restricted>true</restricted>
         <valueSetName>Buildings</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Building__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Building__c.field-meta.xml
@@ -10,7 +10,7 @@
     <trackTrending>false</trackTrending>
     <type>Picklist</type>
     <valueSet>
-        <restricted>true</restricted>
+        <restricted>false</restricted>
         <valueSetName>Buildings</valueSetName>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Name__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Event_Name__c</fullName>
     <description>Event Name</description>
     <externalId>false</externalId>
-    <inlineHelpText>Name of the event</inlineHelpText>
+    <inlineHelpText>Name of the event and displays on the registration page</inlineHelpText>
     <label>Event Name</label>
     <length>80</length>
     <required>false</required>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Status__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Event_Status__c</fullName>
     <description>Status of event (Planning, Active, Inactive, Closed, Cancelled)</description>
     <externalId>false</externalId>
-    <inlineHelpText>Status of event (Planning, Active, Inactive, Closed, Cancelled)</inlineHelpText>
+    <inlineHelpText>Status of event and controls whether it appears on the calendar and in the Instance Feed URL</inlineHelpText>
     <label>Event Status</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Start_Date__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Start_Date__c</fullName>
     <description>Date the event begins</description>
     <externalId>false</externalId>
-    <inlineHelpText>Date the event begins</inlineHelpText>
+    <inlineHelpText>Date registration opens</inlineHelpText>
     <label>Start Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -166,7 +166,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <div class="slds-col slds-p-around_x-small slds-size_1-of-1 slds-large-size_3-of-6">
                                         <div class="slds-form-element slds-is-required">
                                             <apex:outputLabel for="parentLastName" styleClass="slds-form-element__label">
-                                                Parent last name <abbr class="slds-required" title="required">*</abbr>
+                                                Parent Last Name <abbr class="slds-required" title="required">*</abbr>
                                             </apex:outputLabel>
                                             <div class="slds-form-element__control">
                                                 <apex:inputText value="{!newEvtReg.Registrant_Parent_Last_Name__c}" html-aria-describedby="parentLastName-required" id="parentLastName" required="true" styleClass="required requiredText slds-input" maxLength="80"/>
@@ -178,7 +178,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <div class="slds-col slds-p-around_x-small slds-size_1-of-1 slds-large-size_3-of-6">
                                         <div class="slds-form-element slds-is-required">
                                             <apex:outputLabel for="parentEmail" styleClass="slds-form-element__label">
-                                                Parent email <abbr class="slds-required" title="required">*</abbr>
+                                                Parent Email <abbr class="slds-required" title="required">*</abbr>
                                             </apex:outputLabel>
                                             <div class="slds-form-element__control">
                                                 <apex:input type="email" value="{!newEvtReg.Registrant_Parent_Email__c}" id="parentEmail" html-aria-describedby="parentEmail-required" required="true" styleClass="required requiredText validEmail slds-input"/>
@@ -222,7 +222,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <div class="slds-col slds-p-around_x-small slds-size_1-of-1 slds-large-size_3-of-6">
                                         <div class="slds-form-element slds-is-required">
                                             <apex:outputLabel for="otherLastName" styleClass="slds-form-element__label">
-                                                Last name <abbr class="slds-required" title="required">*</abbr>
+                                                Last Name <abbr class="slds-required" title="required">*</abbr>
                                             </apex:outputLabel>
                                             <div class="slds-form-element__control">
                                                 <apex:inputText value="{!newEvtReg.Registrant_Other_Last_Name__c}" id="otherLastName" html-aria-describedby="otherLastName-required" required="true" styleClass="required requiredText slds-input" maxLength="80"/>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -141,7 +141,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 </div>
                             </div>
 
-                            <!-- If applicant is not the student then display these questions-->
+                            <!-- If individual registering is not the registrant then display these questions-->
                             <apex:outputPanel layout="none" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Primary Registrant' || newEvtReg.Registrant_Third_Party_Status__c == '', false, true)}">
 
                                 <!-- Parent questions -->

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -145,7 +145,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                             <apex:outputPanel layout="none" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Primary Registrant' || newEvtReg.Registrant_Third_Party_Status__c == '', false, true)}">
 
                                 <!-- Parent questions -->
-                                <apex:outputPanel layout="block" styleClass="slds-grid slds-wrap" id="parentInfo" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Other', false, true)}" style="width:100%">
+                                <apex:outputPanel layout="block" styleClass="slds-grid slds-wrap" id="parentInfo" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Parent/Guardian', true, false)}" style="width:100%">
 
                                     <div class="slds-col slds-p-around_x-small slds-size_1-of-1">
                                         <h3 class="slds-text-heading_medium">My Information</h3>
@@ -201,7 +201,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 </apex:outputPanel>
 
                                 <!-- OTHER QUESTIONS -->
-                                <apex:outputPanel layout="block" styleClass="slds-grid slds-wrap" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Other', true, false)}" style="width:100%">
+                                <apex:outputPanel layout="block" styleClass="slds-grid slds-wrap" rendered="{!IF(newEvtReg.Registrant_Third_Party_Status__c == 'Parent/Guardian', false, true)}" style="width:100%">
 
                                     <div class="cslds-col slds-p-around_x-small slds-size_1-of-1">
                                         <h3 class="slds-text-heading_medium">My Information</h3>


### PR DESCRIPTION

# Critical Changes
* Change all "Ask" fields default on a new Event record to "Do not ask"
* Updated text on page to be in alignment with like fields (capitalizing some words)
* Increased Capacity Limit to 5 digits
* Updated Helps text on various fields, particular Ask Third Part Registrant guiding users on how to get different values to display based on their needs
* Updated Registration Page so "Parent First Name" and other only show Parent fields when value is "Parent/Guardian".  If any other fields, it will display field labels without "Parent" in them.

# Issues Closed
* No formal issues, but items captured during the September Sprint.