### PR TITLE
Remove allowEdit from the Summit_Events_Registrant

### DIFF
--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1379,7 +1379,7 @@
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>false</allowDelete>
-        <allowEdit>true</allowEdit>
+        <allowEdit>false</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Summit_Events_Appointments__c</object>
@@ -1406,7 +1406,7 @@
     <objectPermissions>
         <allowCreate>true</allowCreate>
         <allowDelete>false</allowDelete>
-        <allowEdit>true</allowEdit>
+        <allowEdit>false</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
         <object>Summit_Events_Registration__c</object>


### PR DESCRIPTION
# Critical Changes
Remove allowEdit from the Summit_Events_Registrant
permission set. Winter '21 release enforces guest site user
security limiting object and sharing access.

# Changes

# Issues Closed
Fixes #205