### PR TITLE
instance title, event title, date escaped in nav crumb

### DIFF
--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -359,13 +359,13 @@ public with sharing class SummitEventsShared {
         crumb += '<nav role="navigation" aria-label="Breadcrumbs">';
         crumb += '   <ol class="slds-breadcrumb slds-list--horizontal">';
         if (String.isNotBlank(eventInstance.Event__r.Event_Name__c)) {
-            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-right_x-small">' + eventTitle + '</li>';
+            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-right_x-small">' +  eventTitle.escapeHtml4() + '</li>';
         }
         if (String.isNotBlank(eventInstance.Instance_Title__c)) {
-            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-horizontal_x-small">' + eventInstanceTitle + '</li>';
+            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-horizontal_x-small">' + eventInstanceTitle.escapeHtml4() + '</li>';
         }
         if (String.isNotBlank(instanceDate)) {
-            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-horizontal_x-small">' + instanceDate + '</li>';
+            crumb += '       <li class="slds-breadcrumb__item slds-text-title--caps slds-p-horizontal_x-small">' + instanceDate.escapeHtml4() + '</li>';
         }
         crumb += '   </ol>';
         crumb += '</nav>';


### PR DESCRIPTION

# Critical Changes

# Changes
- code generated title crumb that included event titles has been escaped to stop XSS attacks

# Issues Closed
