### PR TITLE
Fixed bug with Contact/Lead matching new functionality

### DIFF
--- a/force-app/main/default/classes/SummitEventsContactMatching.cls
+++ b/force-app/main/default/classes/SummitEventsContactMatching.cls
@@ -122,8 +122,12 @@ public with sharing class SummitEventsContactMatching {
                     if (matchType.get(reg.Event__c) == dr.getDuplicateRule()) {
                         for (Datacloud.MatchResult mr : dr.getMatchResults()) {
                             for (Datacloud.MatchRecord mRecord : mr.getMatchRecords()) {
-                                Contact con = (Contact) mRecord.getRecord();
-                                matchContacts.add(con);
+                                try {
+                                    Contact con = (Contact) mRecord.getRecord();
+                                    matchContacts.add(con);
+                                } catch (Exception e){
+                                    System.debug(e);
+                                }
                             }
                         }
                     }
@@ -223,8 +227,12 @@ public with sharing class SummitEventsContactMatching {
                 if (matchingRule == dr.getDuplicateRule()) {
                     for (Datacloud.MatchResult mr : dr.getMatchResults()) {
                         for (Datacloud.MatchRecord mRecord : mr.getMatchRecords()) {
-                            Lead led = (Lead) mRecord.getRecord();
-                            matchLeads.add(led);
+                            try {
+                                Lead led = (Lead) mRecord.getRecord();
+                                matchLeads.add(led);
+                            } catch (Exception e){
+                                System.debug(e);
+                            }
                         }
                     }
                 }

--- a/force-app/main/default/objects/Summit_Events__c/fields/Custom_Metadata_Contact_Matching_Method__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Custom_Metadata_Contact_Matching_Method__c.field-meta.xml
@@ -16,6 +16,26 @@
                 <default>false</default>
                 <label>Admissions</label>
             </value>
+            <value>
+                <fullName>Blue</fullName>
+                <default>false</default>
+                <label>Blue</label>
+            </value>
+            <value>
+                <fullName>Green</fullName>
+                <default>false</default>
+                <label>Green</label>
+            </value>
+            <value>
+                <fullName>Red</fullName>
+                <default>false</default>
+                <label>Red</label>
+            </value>
+            <value>
+                <fullName>Yellow</fullName>
+                <default>false</default>
+                <label>Yellow</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>


### PR DESCRIPTION

# Critical Changes

- Fixed bug caused when Contact Duplicate Rule used both Contact and Lead Matching Rules
- Added four picklist values to Contact Matching Method field on Summit Event object in order to match values on Contact Matching Metadata

# Changes

# Issues Closed
