### PR TITLE
Added 'd' typo for cancel and review

### DIFF
--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Cancel_Review_Title__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Cancel_Review_Title__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Cancel_Review_Title__c</fullName>
-    <description>The title on the page for cancel an review</description>
+    <description>The title on the page for cancel and review</description>
     <externalId>false</externalId>
-    <inlineHelpText>The title on the page for cancel an review</inlineHelpText>
+    <inlineHelpText>The title on the page for cancel and review</inlineHelpText>
     <label>Event Cancel Review Title</label>
     <length>255</length>
     <required>false</required>


### PR DESCRIPTION
# Critical Changes

# Changes

- Updated the label and help text for Summit_Events__c.Event_Cancel_Review_Title__c to include the 'd' in and.

# Issues Closed

- #310