### PR TITLE
Partial fix #267 - Adds feature "Add to calendar" on confirmation page

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -1,0 +1,3 @@
+**/jsconfig.json
+
+**/.eslintrc.json

--- a/force-app/main/default/aura/add2calendarvf/add2calendarvf.app
+++ b/force-app/main/default/aura/add2calendarvf/add2calendarvf.app
@@ -1,0 +1,3 @@
+<aura:application access="GLOBAL" extends="ltng:outAppUnstyled" implements="ltng:allowGuestAccess"> 
+    <aura:dependency resource="%%%NAMESPACE_OR_C%%%:add2Calendar"/>
+</aura:application>

--- a/force-app/main/default/aura/add2calendarvf/add2calendarvf.app-meta.xml
+++ b/force-app/main/default/aura/add2calendarvf/add2calendarvf.app-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <description>A Lightning Application Bundle</description>
+</AuraDefinitionBundle>

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -22,7 +22,7 @@ public with sharing class SummitEventsConfirmationController {
                     SELECT Event_Confirmation_Title__c, Event_Name__c, Template__c, Event_Confirmation_Description__c, Event_Footer__c,
                             Event_Home_Link_Title__c, Event_Home_Link_URL__c, Tracking_Confirmation_Registration__c, Event_Full_Text__c,
                             Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
-                            Hand_Raise_Action__c
+                            Hand_Raise_Action__c,Event_Confirmation_Show_Add_To_Calendar__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -405,6 +405,10 @@
                 <behavior>Edit</behavior>
                 <field>Event_Confirmation_Description__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Confirmation_Show_Add_To_Calendar__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>OneColumn</style>
     </layoutSections>
@@ -573,11 +577,6 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>Clone</actionName>
-            <actionType>StandardButton</actionType>
-            <sortOrder>2</sortOrder>
-        </platformActionListItems>
-        <platformActionListItems>
             <actionName>Edit</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>0</sortOrder>
@@ -586,6 +585,11 @@
             <actionName>Delete</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>1</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>Clone</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>2</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <relatedLists>
@@ -653,7 +657,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h17000007jSSZ</masterLabel>
+        <masterLabel>00h0x000002TwVM</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/lwc/add2Calendar/add2Calendar.html
+++ b/force-app/main/default/lwc/add2Calendar/add2Calendar.html
@@ -1,0 +1,20 @@
+<template>
+    <div class="slds-form-element">
+        <label class="slds-form-element__label" for="add2calendar-select">Add to your calendar:</label>
+        <div class="slds-form-element__control">
+            <div class="slds-select_container">
+                <select class="slds-select" id="add2calendar-select" onchange={handleChange}>
+                    <option value="">--Please choose an option--</option>
+                    <option value="ics">Apple Calendar</option>
+                    <option value="google">Google Calendar</option>
+                    <option value="ics">Outlook Calendar</option>
+                    <option value="outlookweb">Outlook Web Calendar</option>
+                    <option value="yahoo">Yahoo! Calendar</option>
+                </select>
+            </div>
+        </div>
+    </div>
+    <div class="slds-form-element">
+        <a id="add2calendar-a" class={addToCalendarLinkClass} href={addToCalendarLink} role="button" target="_blank">Add Event to Calendar</a>
+    </div>
+</template>

--- a/force-app/main/default/lwc/add2Calendar/add2Calendar.js
+++ b/force-app/main/default/lwc/add2Calendar/add2Calendar.js
@@ -1,0 +1,22 @@
+import { LightningElement,api } from 'lwc';
+
+export default class Add2Calendar extends LightningElement {
+    addToCalendarLink = "#";
+    addToCalendarLinkClass = "slds-hide";
+    @api
+    addToCalendarPage;
+    @api
+    addToCalendarInstanceId;
+
+    handleChange(event) {
+        let index = event.srcElement.selectedIndex;
+        this.addToCalendarLink = this.addToCalendarPage + "?instanceID=" + this.addToCalendarInstanceId;
+        if (index > 0 && index < 6) { 
+            this.addToCalendarLinkClass="slds-button slds-button_neutral";
+            this.addToCalendarLink += ["","","&type=google","","&type=outlookweb","&type=yahoo"][index];
+        } else {
+            this.addToCalendarLink = "#";
+            this.addToCalendarLinkClass = "slds-hide";
+        }
+    }
+}

--- a/force-app/main/default/lwc/add2Calendar/add2Calendar.js-meta.xml
+++ b/force-app/main/default/lwc/add2Calendar/add2Calendar.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/jsconfig.json
+++ b/force-app/main/default/lwc/jsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true
+    },
+    "include": [
+        "**/*",
+        "../../../../.sfdx/typings/lwc/**/*.d.ts"
+    ],
+    "paths": {
+        "c/*": [
+            "*"
+        ]
+    },
+    "typeAcquisition": {
+        "include": [
+            "jest"
+        ]
+    }
+}

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Confirmation_Show_Add_To_Calendar__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Confirmation_Show_Add_To_Calendar__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Confirmation_Show_Add_To_Calendar__c</fullName>
+    <defaultValue>true</defaultValue>
+    <description>Check the box to show an Add To Calendar widget on the registration confirmation page. Default is checked.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Check the box to show an Add To Calendar widget on the registration confirmation page.</inlineHelpText>
+    <label>Event Confirmation Show Add To Calendar</label>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -6,6 +6,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 -->
 
 <apex:page id="SummitEventsConfirmation" showHeader="false" sidebar="false" applyHtmlTag="false" applyBodyTag="false" standardStylesheets="false" docType="html-5.0" cache="false" controller="SummitEventsConfirmationController" action="{!checkEventDetails}">
+    <apex:includeLightning/>
     <apex:composition template="{!templateSelected}">
         <apex:define name="metaPageTitle">
             {!eventPage.Event_Name__c}
@@ -56,6 +57,26 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <apex:outputText escape="false" value="{!eventPage.Event_Confirmation_Description__c}"/>
                             </p>
                         </div>
+                        <div id="add2calendar"/>
+                        <script>
+                            if (<apex:outputText value="{!eventPage.Event_Confirmation_Show_Add_To_Calendar__c}"/>)
+                            $Lightning.use(
+                                "%%%NAMESPACE_OR_C%%%:add2calendarvf", 
+                                function() {
+                                    $Lightning.createComponent(
+                                        "%%%NAMESPACE_OR_C%%%:add2Calendar",
+                                        {
+                                            addToCalendarPage:"SummitEventsAddToCalendar",
+                                            addToCalendarInstanceId:'<apex:outputText value="{!eventInstance.Id}"/>'
+                                        },
+                                        "add2calendar",
+                                        function(cmp) {
+                                            console.log("Add to Calendar component added!");
+                                        }
+                                    );
+                                }
+                            );
+                        </script>
                         <div class="slds-col slds-size_1-of-1 slds-clearfix slds-p-vertical_x-small slds-p-vertical_xx-small">
                             <p class="slds-text-body ">
                                 <apex:outputText escape="false" value="{!EventPage.Event_Footer__c}"/>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1710,6 +1710,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Event_Confirmation_Show_Add_To_Calendar__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Event_Confirmation_Title__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1447,6 +1447,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Event_Confirmation_Show_Add_To_Calendar__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Event_Confirmation_Title__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/reportTypes/Summit_Events_w_Instances.reportType-meta.xml
+++ b/force-app/main/default/reportTypes/Summit_Events_w_Instances.reportType-meta.xml
@@ -505,6 +505,11 @@
             <field>Custom_Metadata_Lead_Matching_Method__c</field>
             <table>Summit_Events__c</table>
         </columns>
+        <columns>
+            <checkedByDefault>false</checkedByDefault>
+            <field>Event_Confirmation_Show_Add_To_Calendar__c</field>
+            <table>Summit_Events__c</table>
+        </columns>
         <masterLabel>Summit Events</masterLabel>
     </sections>
     <sections>


### PR DESCRIPTION
Uses existing SummitEventsAddtoCalendar page functionality for adding events to various calendar types. Some issues may exist with those implementations (Outlook Web did not work for me, didn't test Yahoo), but that's a separate issue.
# Critical Changes

# Changes
Adds LWC "Add To Calendar" widget to registration confirmation page.
Adds checkbox to control showing the LWC on Summit Events object.
Adds FLS on checkbox to permission sets.
Adds checkbox field to page layout.
# Issues Closed
