### PR TITLE
Description, Help Text and Field Labe Update

### DIFF
--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -633,9 +633,9 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>Clone</actionName>
+            <actionName>Edit</actionName>
             <actionType>StandardButton</actionType>
-            <sortOrder>2</sortOrder>
+            <sortOrder>0</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>Delete</actionName>
@@ -643,9 +643,9 @@
             <sortOrder>1</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Edit</actionName>
+            <actionName>Clone</actionName>
             <actionType>StandardButton</actionType>
-            <sortOrder>0</sortOrder>
+            <sortOrder>2</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <relatedLists>
@@ -666,6 +666,7 @@
         <relatedList>Summit_Events_Question__c.Event__c</relatedList>
     </relatedLists>
     <relatedLists>
+        <fields>NAME</fields>
         <fields>Title__c</fields>
         <fields>Appointment_Limits__c</fields>
         <fields>Description__c</fields>
@@ -719,7 +720,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h1h000003IXG5</masterLabel>
+        <masterLabel>00h3F0000071070</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Summit_Events_Appointment_Type__c/Summit_Events_Appointment_Type__c.object-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Appointment_Type__c/Summit_Events_Appointment_Type__c.object-meta.xml
@@ -164,7 +164,7 @@
     <label>Summit Events Appointment Type</label>
     <nameField>
         <displayFormat>AT-{0000}</displayFormat>
-        <label>UG Event Appointment Type</label>
+        <label>Appointment Type Name</label>
         <type>AutoNumber</type>
     </nameField>
     <pluralLabel>Summit Events Appointment Types</pluralLabel>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Donation_Suggested_Amount_List__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Donation_Suggested_Amount_List__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Donation_Suggested_Amount_List__c</fullName>
-    <description>Return separated list of suggested donation amounts. A &quot;Other&quot; category will automatically be added.</description>
+    <description>Return separated list of suggested donation amounts. An &quot;Other&quot; category will automatically be added.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Return separated list of suggested donation amounts. A &quot;Other&quot; category will automatically be added.</inlineHelpText>
+    <inlineHelpText>Return separated list of suggested donation amounts, NUMBERS ONLY, exclude &quot;$&quot;. An &quot;Other&quot; category will automatically be added.</inlineHelpText>
     <label>Donation Suggested Amount List</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/End_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/End_Date__c.field-meta.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>End_Date__c</fullName>
-    <description>Date event ends</description>
+    <description>End date will impact the Event Instance Feed URL. As the End Date changes, the URL will change and update. End date should reflect the range of date Event Instances should appear in the URL.</description>
     <externalId>false</externalId>
-    <inlineHelpText>Date event ends</inlineHelpText>
+    <inlineHelpText>Date the LAST Instance should close.
+
+Note: the Event Instance Feed URL is dynamic and  will update as the end date changes. Registration of the Instance is independent of this end date.</inlineHelpText>
     <label>End Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Private_Event__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Private_Event__c.field-meta.xml
@@ -2,8 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Private_Event__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>Indicate if an event is private and shouldn&apos;t appear on a list/calendar of events.</description>
+    <description>Indicate if an event is private and should not appear on a list/calendar of events.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Indicate if an event is private and should not appear on a list/calendar of events. If selected, all related instances will be removed from the list/calendar.</inlineHelpText>
     <label>Private Event</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Start_Date__c.field-meta.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Start_Date__c</fullName>
-    <description>Date the event begins</description>
+    <description>Start date will impact the Event Instance Feed URL. As the Start Date changes, the URL will change and update. Dates should reflect the range of dates Event Instances should appear in the URL</description>
     <externalId>false</externalId>
-    <inlineHelpText>Date registration opens</inlineHelpText>
+    <inlineHelpText>Date the first Instance should appear on a calendar. This may be when Registration opens.
+Note: the Event Instance Feed URL is dynamic and will update as the start date changes. Registration of the Instance is independent of this start date.</inlineHelpText>
     <label>Start Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>


### PR DESCRIPTION
These are updates from the October Sprint that never got into Master. Most are Description and Help Text updates, but there is also a Field Label change on Appointment Type as "UG Event Appointment Type" is still there from the original. This is one that could have other impacts when packaging, so worth noting next time we package.



# Critical Changes
Field Labe on Appointment Type Record. Worth seeing if packaging creates any issues.

# Changes

# Issues Closed
#363 