### PR TITLE
Bug 380 lookup field not working

### DIFF
--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -227,11 +227,16 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                         quest.setupError += SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, 'reference', true, 'Map To Field: ');
 
                         if (String.isNotBlank(question.Lookup_Fields__c)) {
-                            lookupFields = question.Lookup_Fields__c.split(',');
+                            String questionLookupFields = question.Lookup_Fields__c.toLowerCase();
+                            questionLookupFields = questionLookupFields.replace('billingaddress', 'BillingStreet,BillingCity,BillingState,BillingPostalCode,BillingCountry');
+                            questionLookupFields = questionLookupFields.replace('shippingaddress', 'ShippingStreet,ShippingCity,ShippingState,ShippingPostalCode,ShippingCountry');
+
+                            lookupFields = questionLookupFields.split(',');
 
                             // Test for accessibility and clean up lookup fields
                             for (String lookUpField : lookupFields) {
                                 lookUpField = lookUpField.trim();
+
                                 quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, lookUpField, '', false, 'Look up field: ');
                                 if (String.isBlank(quest.setupError)) {
                                     cleanLookUpFields.add(lookUpField);

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -224,7 +224,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                             quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, '', '', false, '');
                         }
 
-                        quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, mapToField, 'reference', true, 'Map To Field: ');
+                        quest.setupError += SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, 'reference', true, 'Map To Field: ');
 
                         if (String.isNotBlank(question.Lookup_Fields__c)) {
                             lookupFields = question.Lookup_Fields__c.split(',');

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -221,7 +221,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                         lookupObject = '';
                         if (String.isNotBlank(question.Lookup_Object__c)) {
                             lookupObject = question.Lookup_Object__c.trim().toLowerCase();
-                            quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, '', '', false, '');
+                            quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, '', '', false, 'Lookup Object: ');
                         }
 
                         quest.setupError += SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, 'reference', true, 'Map To Field: ');

--- a/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
@@ -236,14 +236,13 @@ private class SummitEventsAdditionalQuestions_TEST {
             SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
-            System.assertEquals(questionController.questionWrapper[0].setupError, 'Question setup issue(s): Map To Field:  may not exist or is inaccessible. Look up field:  may not exist or is inaccessible. Look up field:  may not exist or is inaccessible. ');
+            System.assertEquals(questionController.questionWrapper[0].setupError.trim(), 'Question setup issue(s): Look up field:  may not exist or is inaccessible. Look up field:  may not exist or is inaccessible.');
 
-            //Test question with field that doesn't exist for map_to_field__c
             testQuestions[0].Lookup_Object__c = 'Blah';
             testQuestions[0].Lookup_Fields__c = 'Blah';
             update testQuestions;
             questionController = new SummitEventsAdditionalQuestionsCtlr();
-            System.assertEquals(questionController.questionWrapper[0].setupError, 'Question setup issue(s): blah may not exist or is inaccessible. Map To Field: blah may not exist or is inaccessible. Look up field: blah may not exist or is inaccessible. ');
+            System.assertEquals(questionController.questionWrapper[0].setupError.trim(), 'Question setup issue(s): Lookup Object: blah may not exist or is inaccessible. Look up field: blah may not exist or is inaccessible.');
 
             Test.stopTest();
         }


### PR DESCRIPTION
# Critical Changes
- Fixed error on testing map to fields on lookups for additional questions. Was using lookup object rather than SEA Registration Object
- Expanded compound fields when used in lookup query. BillingAddress or ShippingAddress splits into street/city/state/etc
- Fixed Additional Question object test to new errors created when field accessibility is tested 

# Changes

# Issues Closed
- Closes #380 
