### PR TITLE
Feature 386 eamail lookup layout

### DIFF
--- a/force-app/main/default/classes/SummitEventsLetterheadLookupExtension.cls
+++ b/force-app/main/default/classes/SummitEventsLetterheadLookupExtension.cls
@@ -4,18 +4,20 @@
 // Created by Thaddaeus Dahlberg on 10/11/2018.
 
 public with sharing class SummitEventsLetterheadLookupExtension {
-    public Summit_Events_Email__c SummitEvt;
+    public Summit_Events_Email__c summitEventsEmail;
     public Map<Id, BrandTemplate> brandTemplates;
     public Map<Id, OrgWideEmailAddress> oweList;
 
     public SummitEventsLetterheadLookupExtension(ApexPages.StandardController stdController) {
-        SummitEvt = (Summit_Events_Email__c) stdController.getRecord();
+        summitEventsEmail = (Summit_Events_Email__c) stdController.getRecord();
     }
+
+
 
     public List<SelectOption> getOrgWideEmail() {
         oweList = new Map<Id, OrgWideEmailAddress>(
         [
-                SELECT Id, Address,DisplayName, IsAllowAllProfiles
+                SELECT Id, Address, DisplayName, IsAllowAllProfiles
                 FROM OrgWideEmailAddress
                 WHERE IsAllowAllProfiles = TRUE
                 WITH SECURITY_ENFORCED
@@ -56,13 +58,13 @@ public with sharing class SummitEventsLetterheadLookupExtension {
 
     public PageReference save() {
         ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.INFO, 'Your letterhead settings have been saved.'));
-        if (!String.isBlank(SummitEvt.Org_Email_Id__c)) {
-            SummitEvt.Org_Email__c = String.valueOf(oweList.get(SummitEvt.Org_Email_Id__c).Address);
+        if (!String.isBlank(summitEventsEmail.Org_Email_Id__c)) {
+            summitEventsEmail.Org_Email__c = String.valueOf(oweList.get(summitEventsEmail.Org_Email_Id__c).Address);
         }
         String LHTemplate = '';
-        if (!String.isBlank(SummitEvt.Letterhead_Id__c)) {
-            LHTemplate = brandTemplates.get(SummitEvt.Letterhead_Id__c).Value;
-            SummitEvt.Letterhead_Name__c = brandTemplates.get(SummitEvt.Letterhead_Id__c).Name;
+        if (!String.isBlank(summitEventsEmail.Letterhead_Id__c)) {
+            LHTemplate = brandTemplates.get(summitEventsEmail.Letterhead_Id__c).Value;
+            summitEventsEmail.Letterhead_Name__c = brandTemplates.get(summitEventsEmail.Letterhead_Id__c).Name;
         }
         String headerImg = '';
         String footerImg = '';
@@ -220,8 +222,8 @@ public with sharing class SummitEventsLetterheadLookupExtension {
         generatedLH += '</center>\n';
         generatedLH += '</body>';
 
-        SummitEvt.Letterhead_HTML__c = generatedLH;
-        update SummitEvt;
+        summitEventsEmail.Letterhead_HTML__c = generatedLH;
+        update summitEventsEmail;
 
         return ApexPages.currentPage();
     }

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -199,13 +199,18 @@ public with sharing class SummitEventsShared {
 
         //check if registration id is there and whether status it is set to registered. IF so reset cookie if it is.
         if (String.isNotBlank(eventInformation.registrationId)) {
-            Summit_Events_Registration__c evtReg = [
-                    SELECT Status__c
-                    FROM Summit_Events_Registration__c
-                    WHERE Id = :eventInformation.registrationId
-                    WITH SECURITY_ENFORCED
-            ];
-            if (evtReg.Status__c != 'Started') {
+            Summit_Events_Registration__c evtReg = new Summit_Events_Registration__c();
+            try {
+                evtReg = [
+                        SELECT Status__c
+                        FROM Summit_Events_Registration__c
+                        WHERE Id = :eventInformation.registrationId
+                        WITH SECURITY_ENFORCED
+                ];
+            } catch (Exception ex) {
+
+            }
+            if (evtReg.Status__c != 'Started' || evtReg == null) {
                 eventInformation.registrationId = '';
             }
         }

--- a/force-app/main/default/layouts/Summit_Events_Email__c-Summit Events Email Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Email__c-Summit Events Email Default Layout.layout-meta.xml
@@ -19,6 +19,13 @@
         <label>Information</label>
         <layoutColumns>
             <layoutItems>
+                <height>150</height>
+                <page>SummitEventsLetterheadLookup</page>
+                <showLabel>false</showLabel>
+                <showScrollbars>false</showScrollbars>
+                <width>100%</width>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Readonly</behavior>
                 <field>Name</field>
             </layoutItems>
@@ -123,7 +130,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h2F000000uUUt</masterLabel>
+        <masterLabel>00h23000000PKf1</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events_Email__c-Summit Events Email Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Email__c-Summit Events Email Default Layout.layout-meta.xml
@@ -19,7 +19,7 @@
         <label>Information</label>
         <layoutColumns>
             <layoutItems>
-                <height>150</height>
+                <height>175</height>
                 <page>SummitEventsLetterheadLookup</page>
                 <showLabel>false</showLabel>
                 <showScrollbars>false</showScrollbars>
@@ -130,7 +130,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h23000000PKf1</masterLabel>
+        <masterLabel>00hR0000004Pqew</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/pages/SummitEventsLetterheadLookup.page
+++ b/force-app/main/default/pages/SummitEventsLetterheadLookup.page
@@ -5,40 +5,39 @@ license that can be found in the LICENSE file.
 Created by Thaddaeus Dahlberg on 10/11/2018.
 -->
 
-<apex:page id="SummitEventsLetterheadLookup" showHeader="false" sideBar="false" standardController="Summit_Events_Email__c" extensions="SummitEventsLetterheadLookupExtension">
-    <script>
-        function CloseAndRefresh() {
-            window.opener.location.href = "/{!Summit_Events_Email__c.Id}";
-            self.close();
-        }
-    </script>
+<apex:page id="SummitEventsLetterheadLookup" showHeader="false" sideBar="false" standardController="Summit_Events_Email__c" extensions="SummitEventsLetterheadLookupExtension" standardStylesheets="false">
+    <apex:slds />
+    TEST
     <apex:form id="LetterheadConfig">
-        <apex:pageBlock title="Letterhead Setup">
-            <apex:pageMessages />
-            <apex:pageBlockSection title="Organizational Email to send from" columns="1">
-                <apex:outputText rendered="{!!ISBLANK(Summit_Events_Email__c.Org_Email__c)}">
-                    Currently selected: {!Summit_Events_Email__c.Org_Email__c}
-                </apex:outputText>
-                <apex:selectList multiselect="false" size="1" value="{!Summit_Events_Email__c.Org_Email_Id__c}" required="false" style="width:95%">
-                    <apex:selectOptions value="{!orgWideEmail}"/>
-                </apex:selectList>
-            </apex:pageBlockSection>
-            <apex:pageBlockSection title="Letterheads" columns="1">
-                <apex:outputText rendered="{!!ISBLANK(Summit_Events_Email__c.Letterhead_Id__c)}">
-                    Currently selected: {!Summit_Events_Email__c.Letterhead_Id__c}
-                </apex:outputText>
-                <apex:selectList multiselect="false" size="1" value="{!Summit_Events_Email__c.Letterhead_Id__c}" required="false" style="width:95%">
-                    <apex:selectOptions value="{!Letterheads}"/>
-                </apex:selectList>
-            </apex:pageBlockSection>
-            <apex:pageBlockSection columns="2">
-                <apex:pageBlockSectionItem >
-                    <apex:commandButton value="Save" action="{!save}" onComplete="CloseAndRefresh();"/>
-                </apex:pageBlockSectionItem>
-                <apex:pageBlockSectionItem >
-                    <apex:commandButton value="Close" onClick="window.top.close();"/>
-                </apex:pageBlockSectionItem>
-            </apex:pageBlockSection>
-        </apex:pageBlock>
+        <div class="slds-grid slds-gutters">
+            <div class="slds-col">
+                <div class="slds-form-element">
+                    <apex:outputLabel for="orgWideEmail">Select Organization Wide Email
+                        <br/>Currently selected: {!IF(!ISBLANK(Summit_Events_Email__c.Org_Email__c), Summit_Events_Email__c.Org_Email__c, ' None')}</apex:outputLabel>
+                    <div class="slds-select_container">
+                        <apex:selectList multiselect="false" size="1" value="{!Summit_Events_Email__c.Org_Email_Id__c}" required="false" id="orgWideEmail" styleClass="slds-select">
+                            <apex:selectOptions value="{!orgWideEmail}"/>
+                        </apex:selectList>
+                    </div>
+                </div>
+            </div>
+            <div class="slds-col">
+                <div class="slds-form-element">
+                    <apex:outputLabel for="letterheadLayout">Select classic letterhead layout<br/>
+                        Currently selected: {!IF(!ISBLANK(Summit_Events_Email__c.Letterhead_Id__c), Summit_Events_Email__c.Letterhead_Id__c, ' None')}</apex:outputLabel>
+                    <div class="slds-select_container">
+                        <apex:selectList multiselect="false" size="1" value="{!Summit_Events_Email__c.Letterhead_Id__c}" required="false" id="letterheadLayout" styleClass="slds-select">
+                            <apex:selectOptions value="{!Letterheads}"/>
+                        </apex:selectList>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="slds-grid slds-gutters">
+            <div class="slds-col slds-p-top_medium">
+                <apex:pageMessages />
+                <apex:commandButton value="Save Letterhead settings" action="{!save}" styleClass="slds-button slds-button_brand"/>
+            </div>
+        </div>
     </apex:form>
 </apex:page>

--- a/force-app/main/default/pages/SummitEventsLetterheadLookup.page
+++ b/force-app/main/default/pages/SummitEventsLetterheadLookup.page
@@ -22,7 +22,7 @@ Created by Thaddaeus Dahlberg on 10/11/2018.
             </div>
             <div class="slds-col">
                 <div class="slds-form-element">
-                    <apex:outputLabel for="letterheadLayout">Select classic letterhead layout<br/>
+                    <apex:outputLabel for="letterheadLayout">Select Classic Letterhead<br/>
                         Currently selected: {!IF(!ISBLANK(Summit_Events_Email__c.Letterhead_Id__c), Summit_Events_Email__c.Letterhead_Id__c, ' None')}</apex:outputLabel>
                     <div class="slds-select_container">
                         <apex:selectList multiselect="false" size="1" value="{!Summit_Events_Email__c.Letterhead_Id__c}" required="false" id="letterheadLayout" styleClass="slds-select">

--- a/force-app/main/default/pages/SummitEventsLetterheadLookup.page
+++ b/force-app/main/default/pages/SummitEventsLetterheadLookup.page
@@ -7,7 +7,6 @@ Created by Thaddaeus Dahlberg on 10/11/2018.
 
 <apex:page id="SummitEventsLetterheadLookup" showHeader="false" sideBar="false" standardController="Summit_Events_Email__c" extensions="SummitEventsLetterheadLookupExtension" standardStylesheets="false">
     <apex:slds />
-    TEST
     <apex:form id="LetterheadConfig">
         <div class="slds-grid slds-gutters">
             <div class="slds-col">

--- a/force-app/main/default/pages/SummitEventsLetterheadLookup.page-meta.xml
+++ b/force-app/main/default/pages/SummitEventsLetterheadLookup.page-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>51.0</apiVersion>
-    <availableInTouch>false</availableInTouch>
+    <availableInTouch>true</availableInTouch>
     <confirmationTokenRequired>false</confirmationTokenRequired>
     <label>SummitEventsLetterheadLookup</label>
 </ApexPage>

--- a/force-app/test/default/classes/SummitEventsLetterheadLookup_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsLetterheadLookup_TEST.cls
@@ -30,7 +30,7 @@ public with sharing class SummitEventsLetterheadLookup_TEST {
         );
         emailController.brandTemplates = new Map<Id, BrandTemplate>();
         emailController.brandTemplates.put(fakeBrandTemplate.Id, fakeBrandTemplate);
-        emailController.SummitEvt.Letterhead_Id__c = fakeBrandTemplate.Id;
+        emailController.SummitEventsEmail.Letterhead_Id__c = fakeBrandTemplate.Id;
 
 
         OrgWideEmailAddress fakeOrgWideEmailAddress = new OrgWideEmailAddress (
@@ -40,7 +40,7 @@ public with sharing class SummitEventsLetterheadLookup_TEST {
         );
         emailController.oweList = new Map<Id, OrgWideEmailAddress>();
         emailController.oweList.put(fakeOrgWideEmailAddress.Id, fakeOrgWideEmailAddress);
-        emailController.SummitEvt.Org_Email_Id__c = fakeOrgWideEmailAddress.Id;
+        emailController.SummitEventsEmail.Org_Email_Id__c = fakeOrgWideEmailAddress.Id;
 
         emailController.save();
         List<Summit_Events_Email__c> testSummitEventsEmail = [SELECT Id, Name, Letterhead__c, Letterhead_Id__c, Org_Email_Id__c FROM Summit_Events_Email__c WHERE Event__c = :testEvent.Id];


### PR DESCRIPTION
# Critical Changes

- When an application is deleted while a registrant is still in the process of applying the registration id resets in the encrypted cookie and  redirects to the beginning of the registration. Before the fix the registration pages error and get stuck in an error until the cookie was deleted.

# Changes

- Visualforce page for email letterhead and org-wide email selection has been updated and now is included at the top of the email object layout. Event admins still have to create the record first before the visualforce page can be displayed.

# Issues Closed
- Closes #385
- Closes #386
- Closes #73 