### PR TITLE
Fixed problem in test that would not validate when packaging

### DIFF
--- a/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
+++ b/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
@@ -222,8 +222,7 @@ public with sharing class SummitEventsTestSharedDataFactory {
         List <String> fieldsCreatable = new List <String>();
         for (Schema.SObjectField sField : fieldMap.values()) {
             Schema.DescribeFieldResult dField = sField.getDescribe();
-            if (dField.isCreateable() &&
-                    (String.valueOf(dField.getType()).equalsIgnoreCase('textarea'))) {
+            if (String.valueOf(dField.getType()).equalsIgnoreCase('textarea')) {
                 fieldsCreatable.add(dField.getName());
             }
         }


### PR DESCRIPTION

# Critical Changes

- Unit test was failing during package validation (though not in scratch orgs). Switched logic for identifying available textareas to not test isCreatable since just being a textarea is sufficient on the registration record. Unit tests still run correctly in scratch orgs.

# Changes

# Issues Closed
