### PR TITLE
#431 Resolution - Require Event on Manually Created Reg Records

### DIFF
--- a/force-app/main/default/layouts/Summit_Events_Instance__c-Summit Events Instance Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Instance__c-Summit Events Instance Default Layout.layout-meta.xml
@@ -235,24 +235,29 @@
     <platformActionList>
         <actionListContext>Record</actionListContext>
         <platformActionListItems>
-            <actionName>Edit</actionName>
-            <actionType>StandardButton</actionType>
+            <actionName>Summit_Events_Instance__c.New_Registration</actionName>
+            <actionType>QuickAction</actionType>
             <sortOrder>0</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>Delete</actionName>
+            <actionName>Edit</actionName>
             <actionType>StandardButton</actionType>
             <sortOrder>1</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
-            <actionName>PrintableView</actionName>
+            <actionName>Delete</actionName>
             <actionType>StandardButton</actionType>
-            <sortOrder>3</sortOrder>
+            <sortOrder>2</sortOrder>
         </platformActionListItems>
         <platformActionListItems>
             <actionName>Clone</actionName>
             <actionType>StandardButton</actionType>
-            <sortOrder>2</sortOrder>
+            <sortOrder>3</sortOrder>
+        </platformActionListItems>
+        <platformActionListItems>
+            <actionName>PrintableView</actionName>
+            <actionType>StandardButton</actionType>
+            <sortOrder>4</sortOrder>
         </platformActionListItems>
     </platformActionList>
     <relatedLists>
@@ -309,7 +314,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h11000002pkwW</masterLabel>
+        <masterLabel>00h7g000002EOV8</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
@@ -20,7 +20,7 @@
                 <field>Lead__c</field>
             </layoutItems>
             <layoutItems>
-                <behavior>Edit</behavior>
+                <behavior>Required</behavior>
                 <field>Event__c</field>
             </layoutItems>
             <layoutItems>
@@ -696,7 +696,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h55000002gYmZ</masterLabel>
+        <masterLabel>00h7g000002EOVC</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event__c.field-meta.xml
@@ -6,7 +6,7 @@
     <label>Event</label>
     <referenceTo>Summit_Events__c</referenceTo>
     <relationshipLabel>Summit Events Registrations</relationshipLabel>
-    <relationshipName>UG_Event_Registrations</relationshipName>
+    <relationshipName>Event_Registrations</relationshipName>
     <required>false</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/quickActions/Summit_Events_Instance__c.New_Registration.quickAction-meta.xml
+++ b/force-app/main/default/quickActions/Summit_Events_Instance__c.New_Registration.quickAction-meta.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<QuickAction xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Create a new registration with appropriate related event and instance.</description>
+    <fieldOverrides>
+        <field>Event__c</field>
+        <formula>Summit_Events_Instance__c.Event__c</formula>
+    </fieldOverrides>
+    <fieldOverrides>
+        <field>Event_Instance__c</field>
+        <formula>Summit_Events_Instance__c.Id</formula>
+    </fieldOverrides>
+    <fieldOverrides>
+        <field>Status__c</field>
+        <literalValue>Registered</literalValue>
+    </fieldOverrides>
+    <label>New Registration</label>
+    <optionsCreateFeedItem>true</optionsCreateFeedItem>
+    <quickActionLayout>
+        <layoutSectionStyle>TwoColumnsLeftToRight</layoutSectionStyle>
+        <quickActionLayoutColumns>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Contact__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Registrant_First_Name__c</field>
+                <uiBehavior>Required</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Registrant_Last_Name__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Registrant_Email__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Registrant_Phone__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Registrant_Receive_Texts__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+            <quickActionLayoutItems>
+                <emptySpace>false</emptySpace>
+                <field>Status__c</field>
+                <uiBehavior>Edit</uiBehavior>
+            </quickActionLayoutItems>
+        </quickActionLayoutColumns>
+        <quickActionLayoutColumns/>
+    </quickActionLayout>
+    <successMessage>New Registration Created! Update other fields appropriately.</successMessage>
+    <targetObject>Summit_Events_Registration__c</targetObject>
+    <targetParentField>Event_Instance__c</targetParentField>
+    <type>Create</type>
+</QuickAction>


### PR DESCRIPTION
# Critical Changes

# Changes
* Update Registration Page Layout so Event is required if creating an internally new registration. NOTE: Didn't require field based on test classes errors.
* Created a Quick Action on instance that has a default Event and Instance so only Registrant information is needed (Name, Email, Phone).  One can create a registration from the instance and have it safely associate to the appropriate Event and Instance.
* Remove "UG" from a related list label as that was UST Specific in past. 
* Added the Quick Action to the Instance Layout.

# Issues Closed
Resolves #431 