### PR TITLE
Rollup Field on Instance Update

### DIFF
--- a/force-app/main/default/objects/Summit_Events_Instance__c/fields/Primary_Attendees__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Instance__c/fields/Primary_Attendees__c.field-meta.xml
@@ -8,7 +8,7 @@
     <summaryFilterItems>
         <field>Summit_Events_Registration__c.Status__c</field>
         <operation>notEqual</operation>
-        <value>Cancelled, Rescheduled</value>
+        <value>Cancelled, Rescheduled, Started</value>
     </summaryFilterItems>
     <summaryForeignKey>Summit_Events_Registration__c.Event_Instance__c</summaryForeignKey>
     <summaryOperation>count</summaryOperation>


### PR DESCRIPTION
Updated the Rollup Field to ensure that when Individual Registrants is selected, it does NOT count "Started" registrants.

# Critical Changes

# Changes

# Issues Closed
Close #415 