### PR TITLE
April fix before packaging

### DIFF
--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -66,7 +66,8 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
 
             eventPage = [
                     SELECT Name, Id, Event_Name__c, Event_description__c, Event_Footer__c, Event_Full_Text__c, Event_Home_Link_URL__c, Event_Home_Link_Title__c,
-                            Template__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Event_Additional_Question_Title__c, Event_Additional_Questions_Description__c
+                            Template__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Event_Additional_Question_Title__c, Event_Additional_Questions_Description__c,
+                            Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED
@@ -141,7 +142,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     String mapToField = '';
                     String lookupObject = '';
 
-                    if(String.isBlank(question.Display_Style__c)) {
+                    if (String.isBlank(question.Display_Style__c)) {
                         quest.displayStyle = 'slds-large-size_3-of-6';
                     } else if (question.Display_Style__c.equalsIgnoreCase('full width')) {
                         quest.displayStyle = 'slds-large-size_6-of-6';

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -136,12 +136,13 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     String mapToField = '';
                     String lookupObject = '';
 
-                    if (String.isBlank(question.Display_Style__c)) {
-                        quest.displayStyle = 'slds-large-size_3-of-6';
-                    } else if (question.Display_Style__c.equalsIgnoreCase('full width')) {
-                        quest.displayStyle = 'slds-large-size_6-of-6';
-                    } else if (question.Display_Style__c.equalsIgnoreCase('third width')) {
-                        quest.displayStyle = 'slds-large-size_2-of-6';
+                    quest.displayStyle = 'slds-large-size_3-of-6';
+                    if (String.isNotBlank(question.Display_Style__c)) {
+                        if (question.Display_Style__c.equalsIgnoreCase('full width')) {
+                            quest.displayStyle = 'slds-large-size_6-of-6';
+                        } else if (question.Display_Style__c.equalsIgnoreCase('third width')) {
+                            quest.displayStyle = 'slds-large-size_2-of-6';
+                        }
                     }
 
                     //Make sure this is really a field

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -45,6 +45,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
         public String secondaryNoResults { get; set; }
         public String setupError { get; set; }
         public Boolean setupFail { get; set; }
+        public String displayStyle { get; set; }
     }
 
     public class queryReturn {
@@ -102,7 +103,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     SELECT Name, Question_Label__c, Question_Field_Type__c, Default_Value__c, Registrant_Type__c, Instructions__c, Help_Text__c, Display_Order__c,
                             Map_to_Field__c, Picklist_Values__c, Text_Limit__c, Controlling_Question__c, Controlling_Logic__c, Required__c, Is_Visible__c, Error_Assist_Text__c,
                             Lookup_Object__c, Lookup_Fields__c, Lookup_Where_Clause__c, Lookup_No_Results_Label__c, Lookup_Secondary_Input_Link_Text__c, Lookup_Secondary_Value_Field__c,
-                            Lookup_Secondary_Input_Instructions__c, Lookup_Results_Icon__c, Existing_Picklist_Values__c
+                            Lookup_Secondary_Input_Instructions__c, Lookup_Results_Icon__c, Existing_Picklist_Values__c, Display_Style__c
                     FROM Summit_Events_Question__c
                     WHERE Event__c = :eventInformation.eventId
                     AND (Registrant_Type__c = 'Registrant' OR Registrant_Type__c = 'Registrant and Guest')
@@ -139,6 +140,14 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     quest.setupError = '';
                     String mapToField = '';
                     String lookupObject = '';
+
+                    if(String.isBlank(question.Display_Style__c)) {
+                        quest.displayStyle = 'slds-large-size_3-of-6';
+                    } else if (question.Display_Style__c.equalsIgnoreCase('full width')) {
+                        quest.displayStyle = 'slds-large-size_6-of-6';
+                    } else if (question.Display_Style__c.equalsIgnoreCase('third width')) {
+                        quest.displayStyle = 'slds-large-size_2-of-6';
+                    }
 
                     //Make sure this is really a field
                     if (String.isBlank(question.Map_to_Field__c)) {

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -18,7 +18,6 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
     public String formattedNavDate { get; set; }
     public List<Summit_Events_Question__c> additionalQuestions { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public List<String> mapToList { get; set; }
     public List<questionItem> questionWrapper { get; set; }
     private Id incomingRegId { get; set; }
@@ -92,12 +91,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
             startTimeString = SeaShared.formatTime(eventInstance.Instance_Start_Time__c, false);
             endTimeString = SeaShared.formatTime(eventInstance.Instance_End_Time__c, false);
 
-            if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                eventIsClosed = adminOpen;
-            } else {
-                eventIsClosed = SeaShared.isEventClosed(eventInstance);
-            }
+            eventIsClosed = SeaShared.isEventClosed(eventInstance);
 
             //Get the question object questions
             additionalQuestions = [

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -96,7 +96,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                 adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                 eventIsClosed = adminOpen;
             } else {
-                eventIsClosed = SeaShared.isEventClosed(eventPage, eventInstance);
+                eventIsClosed = SeaShared.isEventClosed(eventInstance);
             }
 
             //Get the question object questions

--- a/force-app/main/default/classes/SummitEventsCancelReviewController.cls
+++ b/force-app/main/default/classes/SummitEventsCancelReviewController.cls
@@ -13,6 +13,7 @@ public with sharing class SummitEventsCancelReviewController {
     public Boolean eventNotFound { get; set; }
     public String formattedNavDate { get; set; }
     public String eventParameter { get; set; }
+    public Summit_Events_Instance__c eventInstance { get; set; }
 
     public SummitEventsCancelReviewController() {
         eventParameter = ApexPages.currentPage().getParameters().get('eventInfo');
@@ -36,7 +37,8 @@ public with sharing class SummitEventsCancelReviewController {
                                     Event__r.Template__c, Event__r.Event_Home_Link_Title__c, Event__r.Event_Home_Link_URL__c,
                                     Event_Instance__r.Instance_Start_Date__c, Event_Instance__r.Instance_Start_Time__c,
                                     Event_Instance__r.Instance_End_Date__c, Event_Instance__r.Instance_End_Time__c, Event_Instance__r.Instance_Time_Zone__c,
-                                    Event__r.Tracking_Cancel_Registration__c
+                                    Event__r.Tracking_Cancel_Registration__c, Event__r.Account__r.Name, Event__r.Audience__c,
+                                    Event__r.Filter_Category__c, Event__r.Event_Sponsor__c
                             FROM Summit_Events_Registration__c
                             WHERE Id = :eventInformation.registrationId
                             WITH SECURITY_ENFORCED
@@ -56,7 +58,7 @@ public with sharing class SummitEventsCancelReviewController {
                                 WITH SECURITY_ENFORCED
                         ];
 
-                        List<Summit_Events_Instance__c> eventInstance = [
+                        eventInstance = [
                                 SELECT Id, Event__r.Event_Name__c, Instance_Title__c,
                                         Instance_Start_Date__c, Instance_End_Date__c, Instance_Start_Time__c, Instance_End_Time__c, Instance_Time_Zone__c
                                 FROM Summit_Events_Instance__c W
@@ -68,8 +70,8 @@ public with sharing class SummitEventsCancelReviewController {
                             eventOver = true;
                         }
 
-                        if (eventInstance.size() > 0) {
-                            formattedNavDate = SEShared.navBreadcrumbBuilder(eventInstance[0]);
+                        if (eventInstance != null) {
+                            formattedNavDate = SEShared.navBreadcrumbBuilder(eventInstance);
                         }
                         eventNotFound = false;
                     }

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -11,7 +11,6 @@ public with sharing class SummitEventsConfirmationController {
     public String templateSelected { get; set; }
     public String formattedNavDate { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public Summit_Events_Registration__c eventRegistration { get; set; }
     public Map <String, String> feesByIndex { get; set; }
     public List<Summit_Events_Fee__c> eventFees { get; set; }
@@ -60,17 +59,7 @@ public with sharing class SummitEventsConfirmationController {
                             LIMIT 1
                     ];
 
-                    if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                        adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                        if (adminOpen) {
-                            PageReference eventDetailsPageReference = checkEventDetails();
-                            if (eventDetailsPageReference == null) {
-                                eventIsClosed = seaShared.isEventClosed(eventInstance);
-                            }
-                        }
-                    } else {
-                        eventIsClosed = seaShared.isEventClosed(eventInstance);
-                    }
+                    eventIsClosed = seaShared.isEventClosed(eventInstance);
 
                     formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
                 }
@@ -97,13 +86,7 @@ public with sharing class SummitEventsConfirmationController {
         Boolean eventRegistrationSuccess = true;
 
         //Make sure the event has not expired
-        eventIsClosed = false;
-        if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-            adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-            eventIsClosed = adminOpen;
-        } else {
-            eventIsClosed = seaShared.isEventClosed(eventInstance);
-        }
+        eventIsClosed = seaShared.isEventClosed(eventInstance);
 
         // Default to submit page, submit will redirect to beginning if no reg id is present. Prevents pre-filled forms in one step registrations.
         ApexPages.currentPage().getHeaders().put('referer', Page.SummitEventsSubmit.getUrl());

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -94,7 +94,7 @@ public with sharing class SummitEventsConfirmationController {
         eventIsClosed = false;
         if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
             adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-            eventIsClosed = !adminOpen;
+            eventIsClosed = adminOpen;
         } else {
             eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
         }

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -62,10 +62,16 @@ public with sharing class SummitEventsConfirmationController {
 
                     if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
                         adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                        eventIsClosed = adminOpen;
+                        if (adminOpen) {
+                            PageReference eventDetailsPageReference = checkEventDetails();
+                            if (eventDetailsPageReference == null) {
+                                eventIsClosed = seaShared.isEventClosed(eventInstance);
+                            }
+                        }
                     } else {
-                        eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
+                        eventIsClosed = seaShared.isEventClosed(eventInstance);
                     }
+
                     formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
                 }
 
@@ -96,7 +102,7 @@ public with sharing class SummitEventsConfirmationController {
             adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
             eventIsClosed = adminOpen;
         } else {
-            eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
+            eventIsClosed = seaShared.isEventClosed(eventInstance);
         }
 
         // Default to submit page, submit will redirect to beginning if no reg id is present. Prevents pre-filled forms in one step registrations.

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -41,7 +41,7 @@ public with sharing class SummitEventsConfirmationController {
                     SELECT Event_Confirmation_Title__c, Event_Name__c, Template__c, Event_Confirmation_Description__c, Event_Footer__c,
                             Event_Home_Link_Title__c, Event_Home_Link_URL__c, Tracking_Confirmation_Registration__c, Event_Full_Text__c,
                             Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
-                            Hand_Raise_Action__c
+                            Hand_Raise_Action__c, Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsDonationController.cls
+++ b/force-app/main/default/classes/SummitEventsDonationController.cls
@@ -67,7 +67,7 @@ public with sharing class SummitEventsDonationController {
                 adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                 eventIsClosed = adminOpen;
             } else {
-                eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
+                eventIsClosed = seaShared.isEventClosed(eventInstance);
             }
 
             formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);

--- a/force-app/main/default/classes/SummitEventsDonationController.cls
+++ b/force-app/main/default/classes/SummitEventsDonationController.cls
@@ -29,7 +29,7 @@ public with sharing class SummitEventsDonationController {
                             Tracking_Submit_Registration__c, Event_Full_Text__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Donation_Suggested_Amount_List__c,
                             Donation_Description__c, Display_Optional_Donation__c, Donation_Allocation_1__c, Donation_Allocation_2__c, Donation_Allocation_3__c, Donation_Allocation_4__c,
                             Donation_Allocation_5__c, Donation_Allocation_1__r.Name, Donation_Allocation_2__r.Name, Donation_Allocation_3__r.Name, Donation_Allocation_4__r.Name,
-                            Donation_Allocation_5__r.Name, Donation_Title__c
+                            Donation_Allocation_5__r.Name, Donation_Title__c, Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsDonationController.cls
+++ b/force-app/main/default/classes/SummitEventsDonationController.cls
@@ -14,7 +14,6 @@ public with sharing class SummitEventsDonationController {
     public String donationAmount { get; set; }
     public Summit_Events_Fee__c incomingFee { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public String formattedNavDate { get; set; }
     public Map<String, PageReference> pageFlow {get;set;}
@@ -63,12 +62,7 @@ public with sharing class SummitEventsDonationController {
                 donationAmountSelect = String.valueOf(incomingFee.Event_Fee__c);
             }
 
-            if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                eventIsClosed = adminOpen;
-            } else {
-                eventIsClosed = seaShared.isEventClosed(eventInstance);
-            }
+            eventIsClosed = seaShared.isEventClosed(eventInstance);
 
             formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
         }

--- a/force-app/main/default/classes/SummitEventsFeed.cls
+++ b/force-app/main/default/classes/SummitEventsFeed.cls
@@ -251,7 +251,7 @@ global with sharing class SummitEventsFeed {
             eventQuery += ' AND (' + sanitizeOrLikeList(accountName, 'Event__r.Account__r.Name') + ') ';
         }
 
-        //School filter (can be comma separated)
+        //Building filter (can be comma separated)
         String building = req.params.get('building');
         if (String.isNotBlank(building)) {
             eventQuery += ' AND (' + sanitizeOrLikeList(building, 'Event__r.Building__c') + ') ';
@@ -468,9 +468,6 @@ global with sharing class SummitEventsFeed {
         }
         return '';
     }
-
-
-//eventQuery += ' Event__r.Program_Filter__c LIKE \'%' + f + '%\' OR ';
 
     private static Map<String, String> getAudienceDD(Schema.DescribeFieldResult fieldResult) {
         Map<String, String> fieldMap = new Map<String, String>();

--- a/force-app/main/default/classes/SummitEventsFeed.cls
+++ b/force-app/main/default/classes/SummitEventsFeed.cls
@@ -15,6 +15,8 @@ global with sharing class SummitEventsFeed {
     public class eventItem {
         public String ID { get; set; }
         public String title { get; set; }
+        public String title_event { get; set; }
+        public String title_instance { get; set; }
         public String instanceDesc { get; set; }
         public String description { get; set; }
         public String longDesc { get; set; }
@@ -99,7 +101,7 @@ global with sharing class SummitEventsFeed {
 
         //Check if account is accessible
         Boolean accountIsAccessible = false;
-        if (Schema.sObjectType.Account.isAccessible()) {
+        if (Schema.SObjectType.Account.isAccessible()) {
             accountIsAccessible = true;
         }
 
@@ -293,12 +295,15 @@ global with sharing class SummitEventsFeed {
 
             if (eventInstance.Event__r.Event_Name__c != null) {
                 evt.title = seaShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
+                evt.title_event = seaShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
             } else {
                 evt.title = seaShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
+                evt.title_event = seaShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
             }
 
-            if (eventInstance.Instance_Title__c != null) {
+            if (String.isNotBlank(eventInstance.Instance_Title__c)) {
                 evt.title += ' - ' + seaShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
+                evt.title_instance = seaShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
             }
 
             if (String.isNotBlank(eventInstance.Instance_Short_Description__c)) {

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -11,7 +11,6 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
     public Summit_Events_Instance__c evtInstance { get; set; }
     public String incomingAppointmentJSON { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public String templateSelected { get; set; }
     public Boolean noOptionalAppointments { get; set; }
@@ -68,12 +67,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
                 pageFlow = seaShared.getPageFlow(eventInformation.eventId, evtInstance.Instance_Title__c, ApexPages.currentPage(), evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c);
 
-                if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                    adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                    eventIsClosed = adminOpen;
-                } else {
-                    eventIsClosed = seaShared.isEventClosed(evtInstance);
-                }
+                eventIsClosed = seaShared.isEventClosed(evtInstance);
 
                 if (evtInstance != null) {
                     String dayOfWeek = seaShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -48,7 +48,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                     SELECT Event_Name__c, Event_description__c, Event_Appointment_Title__c, Event_Appointment_Description__c, Event_Footer__c,
                             Template__c, Event_Home_Link_Title__c, Event_Home_Link_URL__c, Tracking_Options_Registration__c, Event_Full_Text__c,
                             Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Display_Optional_Donation__c, Event_Appointment_Chosen_Label__c,
-                            Event_Appointment_Unchosen_Label__c, Event_Appointment_Next_Instructions__c
+                            Event_Appointment_Unchosen_Label__c, Event_Appointment_Next_Instructions__c, Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -72,7 +72,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                     adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                     eventIsClosed = adminOpen;
                 } else {
-                    eventIsClosed = seaShared.isEventClosed(eventPage, evtInstance);
+                    eventIsClosed = seaShared.isEventClosed(evtInstance);
                 }
 
                 if (evtInstance != null) {

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -24,6 +24,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
         public String appId { get; set; }
         public String appCategory { get; set; }
         public String appType { get; set; }
+        public Boolean appTypeSet { get; set; }
         public String appTitle { get; set; }
         public String appChosenState { get; set; }
         public String appDesc { get; set; }
@@ -153,6 +154,9 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                             addAppointment.appLimit = appLimit;
                             addAppointment.appRequired = apt.Required_Appointment__c;
                             addAppointment.inputRequired = false;
+                            if(String.isNotBlank(apt.Appointment_Type__c)) {
+                                addAppointment.appTypeSet = true;
+                            }
 
                             if (String.isNotBlank(apt.Registrant_Input__c) && apt.Registrant_Input__c.containsIgnoreCase('Required')) {
                                 addAppointment.inputRequired = true;
@@ -161,9 +165,8 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                             if (apt.Appointment_Category__c != null) {
                                 Map<String, String> dependencies = seaShared.getDependentSelectOptions('Summit_Events_Appointment_Type__c', 'Appointment_Category__c', 'Appointment_Type__c', apt.Appointment_Category__c);
                                 List<String> pickListItems = new List<String>();
-
-                                if (dependencies.size() > 1) {
-
+                                System.debug(dependencies);
+                                if (dependencies.size() > 0) {
                                     for (String item : dependencies.keySet()) {
                                         pickListItems.add(dependencies.get(item));
                                     }
@@ -252,6 +255,9 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
             addAppointment.Chosen_State__c = app.appChosenState;
             if (String.isNotBlank(app.appCategory) && app.appCategory != 'null' && app.appCategory != 'undefined') {
                 addAppointment.Appointment_Category__c = app.appCategory;
+                if (String.isNotBlank(app.appInput) && String.isBlank(addAppointment.Appointment_Type__c)) {
+                    addAppointment.Appointment_Type__c = app.appInput;
+                }
             }
             if (String.isNotBlank(app.appInput)) {
                 addAppointment.Registrant_Input__c = app.appInput;

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -233,7 +233,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
             //Set know states
             addAppointment.Event_Registration__c = eventInformation.registrationId;
-            addAppointment.Appointment_Status__c = 'Registered';
+            addAppointment.Appointment_Status__c = 'Requested';
             addAppointment.Client_Created_Appointment__c = true;
 
             if (!String.isBlank(appDefinition.Auto_add_building__c)) {

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -103,7 +103,6 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                     for (Summit_Events_Appointment_Type__c chosenCheck : appointments.values()) {
                         if (chosenCheck.Chosen_State__c != 'Added and Required' && chosenCheck.Chosen_State__c != 'Added but not shown') {
                             noOptionalAppointments = false;
-                            break;
                         }
                     }
 

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -136,7 +136,7 @@ public with sharing class SummitEventsRegisterController {
                             First_Name_Label__c, Gender_Label__c, Last_Name_As_Student_Label__c, Last_Name_Label__c, Mailing_Address_Label__c,
                             Phone_Label__c, Phone_Type_Label__c, Preferred_First_Name_Label__c, Pronouns_Label__c, Registrant_Receive_Texts_Label__c,
                             Relationship_To_Institution_Label__c, Third_Party_Registrant_Label__c, Title_Label__c, Preferred_Class_Year_Label__c,
-                            Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c
+                            Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c, Account__r.Name
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED
@@ -279,7 +279,8 @@ public with sharing class SummitEventsRegisterController {
             if (String.isBlank(eventInformation.registrationId)) {
 
                 userContact = [
-                        SELECT Id, Name, FirstName, LastName, Email, HomePhone, MobilePhone, Birthdate
+                        SELECT Id, Name, FirstName, LastName, Email, HomePhone, MobilePhone, Birthdate, MailingStreet,
+                                MailingState, MailingCountry, MailingPostalCode, MailingCity
                         FROM Contact
                         WHERE Id IN (
                                 SELECT ContactId
@@ -289,12 +290,20 @@ public with sharing class SummitEventsRegisterController {
                         WITH SECURITY_ENFORCED
                 ];
 
+                eventRegistration.Registrant_Street_1__c = userContact.MailingStreet;
+                eventRegistration.Registrant_State__c = userContact.MailingState;
+                eventRegistration.Registrant_Country__c = userContact.MailingCountry;
+                eventRegistration.Registrant_Postal_Code__c = userContact.MailingPostalCode;
+                eventRegistration.Registrant_Zip__c = userContact.MailingPostalCode;
+                eventRegistration.Registrant_City__c = userContact.MailingCity;
                 eventRegistration.Registrant_First_Name__c = userContact.FirstName;
                 eventRegistration.Registrant_Last_Name__c = userContact.LastName;
                 eventRegistration.Registrant_Email__c = userContact.Email;
                 eventRegistration.Registrant_Phone__c = userContact.HomePhone;
                 eventRegistration.Registrant_Mobile_Phone__c = userContact.MobilePhone;
                 eventRegistration.Registrant_Date_of_Birth__c = userContact.Birthdate;
+                eventRegistration.Contact__c = userContact.Id;
+
                 if (userContact.Birthdate != null) {
                     birthDateString = userContact.Birthdate.format();
                 }
@@ -505,7 +514,7 @@ public with sharing class SummitEventsRegisterController {
 
         eventInformation.registrationId = eventRegistration.Id;
 
-        String dayOfWeek = seaShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
+        String dayOfWeek = SeaShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
         //Insert pre-chosen appointments for appointments page
         List<Summit_Events_Appointment_Type__c> autoAddAppt = [
                 SELECT Id, Name, Title__c, Description__c, Appointment_Type__c, Appointment_Category__c, Registrant_Input__c, Custom_Picklist__c, Appointment_Limits__c,
@@ -514,7 +523,7 @@ public with sharing class SummitEventsRegisterController {
                 WHERE Summit_Events__c = :eventInformation.eventId
                 AND (Chosen_State__c = 'Added' OR Chosen_State__c = 'Added and Required' OR Chosen_State__c = 'Added but not shown')
                 AND Id NOT IN (SELECT Event_Appointment_Type__c FROM Summit_Events_Appointments__c WHERE Event_Registration__c = :eventInformation.registrationId)
-                AND (Restrict_To_Instance_Title__r.Instance_Title__c = :evtInstance.Instance_Title__c OR Restrict_To_Instance_Title__r.Instance_Title__c = null OR Restrict_To_Instance_Title__r.Instance_Title__c = '')
+                AND (Restrict_To_Instance_Title__r.Instance_Title__c = :evtInstance.Instance_Title__c OR Restrict_To_Instance_Title__r.Instance_Title__c = NULL OR Restrict_To_Instance_Title__r.Instance_Title__c = '')
                 AND (Date_Available_Start__c <= :evtInstance.Instance_Start_Date__c OR Date_Available_Start__c = NULL)
                 AND (Date_Available_End__c >= :evtInstance.Instance_End_Date__c OR Date_Available_End__c = NULL)
                 AND (Day_of_Week_Availability__c INCLUDES (:dayOfWeek) OR Day_of_Week_Availability__c = NULL)
@@ -528,7 +537,11 @@ public with sharing class SummitEventsRegisterController {
             addAppt.Event_Appointment_Type__c = appt.Id;
             addAppt.Event_Registration__c = eventInformation.registrationId;
             addAppt.Appointment_Title__c = appt.Title__c;
-            addAppt.Appointment_Status__c = 'Registered';
+            if (appt.Auto_Confirm_Appointment__c) {
+                addAppt.Appointment_Status__c = 'Confirmed';
+            } else {
+                addAppt.Appointment_Status__c = 'Registered';
+            }
             addAppt.Appointment_Category__c = appt.Appointment_Category__c;
             addAppt.Appointment_Type__c = appt.Appointment_Type__c;
             addAppt.Appointment_Detail__c = appt.Description__c;

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -270,6 +270,32 @@ public with sharing class SummitEventsRegisterController {
                 ));
             }
 
+            /*get Analytic data*/
+
+            //Get current URL
+            String baseURL = URL.getSalesforceBaseUrl().toExternalForm(); // it will return: < https://cs14.salesforce.com >
+            String PageURL = ApexPages.currentPage().getUrl();   // it will return: < /apex/myVFpage?id=906F00000008w9wIAA >
+            eventRegistration.Event_Website__c = baseURL + PageURL.replace('\'', '').escapeHtml4();
+
+            //Get referrer url if not blank
+            if (String.isNotBlank(ApexPages.currentPage().getHeaders().get('Referer'))) {
+                eventRegistration.Event_Website_Referrer__c = ApexPages.currentPage().getHeaders().get('Referer').replace('\'', '').escapeHtml4();
+            }
+
+            List<String> analyticCodes = new List<String>{
+                    'gclid__c', 'utm_campaign__c', 'utm_content__c',
+                    'utm_creative_format__c', 'utm_id__c', 'utm_marketing_tactic__c', 'utm_medium__c', 'utm_source__c', 'utm_source_platform__c', 'utm_term__c'
+            };
+
+            for (String code : analyticCodes) {
+                if (String.isNotBlank(ApexPages.currentPage().getParameters().get(code))) {
+                    String codeValue = ApexPages.currentPage().getParameters().get(code);
+                    codeValue = codeValue.replace('\'', '');
+                    codeValue = codeValue.escapeHtml4();
+                    eventRegistration.put(code, codeValue);
+                }
+            }
+
         }
 
         //If the user is logged in use that data
@@ -327,8 +353,10 @@ public with sharing class SummitEventsRegisterController {
                         Registrant_High_School__c, Registrant_High_School_Code__c, Registrant_Receive_Texts__c, Registrant_High_School_Grad_Year__c, Registrant_High_School_Not_Found__c,
                         Registrant_College_Not_Found__c, Registrant_Parent_First_Name__c, Registrant_Parent_Last_Name__c, Registrant_Parent_Email__c, Registrant_Parent_Phone__c,
                         Add_Info_Answer_1__c, Add_Info_Answer_2__c, Add_Info_Answer_3__c, Add_Info_Answer_4__c, Add_Info_Answer_5__c, Registrant_Program_Interest__c, Registrant_Preferred_First_Name__c,
-                        Registrant_Date_of_Birth__c, Last_Name_as_Student__c, Preferred_Class_Year__c, Relationship_To_Institution__c, Registrant_Other_Email__c, Registrant_Other_First_Name__c, Registrant_Other_Last_Name__c, Registrant_Other_Phone__c, Registrant_Other_Relationship__c,
-                        Registrant_Country__c, Registrant_State_Province__c, Registrant_Postal_Code__c, Registrant_Third_Party_Status__c, Registrant_Pronouns__c, Registrant_Title__c, Registrant_Company_Organization__c
+                        Registrant_Date_of_Birth__c, Last_Name_as_Student__c, Preferred_Class_Year__c, Relationship_To_Institution__c, Registrant_Other_Email__c, Registrant_Other_First_Name__c, Registrant_Other_Last_Name__c,
+                        Registrant_Other_Phone__c, Registrant_Other_Relationship__c, Registrant_Country__c, Registrant_State_Province__c, Registrant_Postal_Code__c, Registrant_Third_Party_Status__c,
+                        Registrant_Pronouns__c, Registrant_Title__c, Registrant_Company_Organization__c, Event_Website__c, Event_Website_Referrer__c, gclid__c, utm_campaign__c, utm_content__c,
+                        utm_creative_format__c, utm_id__c, utm_marketing_tactic__c, utm_medium__c, utm_source__c, utm_source_platform__c, utm_term__c
                 FROM Summit_Events_Registration__c
                 WHERE Id = :eventRegistrationId
                 WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -537,6 +537,7 @@ public with sharing class SummitEventsRegisterController {
             addAppt.Event_Appointment_Type__c = appt.Id;
             addAppt.Event_Registration__c = eventInformation.registrationId;
             addAppt.Appointment_Title__c = appt.Title__c;
+            //If appointment is not shown and auto confirmed confirm it!
             if (appt.Auto_Confirm_Appointment__c) {
                 addAppt.Appointment_Status__c = 'Confirmed';
             } else {

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -284,8 +284,8 @@ public with sharing class SummitEventsRegisterController {
             }
 
             List<String> analyticCodes = new List<String>{
-                    'gclid__c', 'utm_campaign__c', 'utm_content__c',
-                    'utm_creative_format__c', 'utm_id__c', 'utm_marketing_tactic__c', 'utm_medium__c', 'utm_source__c', 'utm_source_platform__c', 'utm_term__c'
+                    'gclid__c', 'utm_campaign__c', 'utm_content__c', 'utm_creative_format__c', 'utm_id__c',
+                    'utm_marketing_tactic__c', 'utm_medium__c', 'utm_source__c', 'utm_source_platform__c', 'utm_term__c'
             };
 
             for (String code : analyticCodes) {

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -136,7 +136,8 @@ public with sharing class SummitEventsRegisterController {
                             First_Name_Label__c, Gender_Label__c, Last_Name_As_Student_Label__c, Last_Name_Label__c, Mailing_Address_Label__c,
                             Phone_Label__c, Phone_Type_Label__c, Preferred_First_Name_Label__c, Pronouns_Label__c, Registrant_Receive_Texts_Label__c,
                             Relationship_To_Institution_Label__c, Third_Party_Registrant_Label__c, Title_Label__c, Preferred_Class_Year_Label__c,
-                            Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c, Account__r.Name
+                            Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c, Account__r.Name,
+                            Filter_Category__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED
@@ -273,8 +274,8 @@ public with sharing class SummitEventsRegisterController {
             /*get Analytic data*/
 
             //Get current URL
-            String baseURL = URL.getSalesforceBaseUrl().toExternalForm(); // it will return: < https://cs14.salesforce.com >
-            String PageURL = ApexPages.currentPage().getUrl();   // it will return: < /apex/myVFpage?id=906F00000008w9wIAA >
+            String baseURL = Url.getSalesforceBaseUrl().toExternalForm();
+            String PageURL = ApexPages.currentPage().getUrl();
             eventRegistration.Event_Website__c = baseURL + PageURL.replace('\'', '').escapeHtml4();
 
             //Get referrer url if not blank

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -167,7 +167,7 @@ public with sharing class SummitEventsRegisterController {
                 adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                 eventIsClosed = adminOpen;
             } else {
-                eventIsClosed = SeaShared.isEventClosed(eventPage, evtInstance);
+                eventIsClosed = SeaShared.isEventClosed(evtInstance);
             }
 
             if (

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -572,6 +572,12 @@ public with sharing class SummitEventsRegisterController {
             } else {
                 addAppt.Appointment_Status__c = 'Registered';
             }
+            if (String.isNotBlank(appt.Auto_add_building__c)) {
+                addAppt.Building__c = appt.Auto_add_building__c;
+            }
+            if (appt.Auto_Add_Time__c != null) {
+                addAppt.Appointment_Time__c = appt.Auto_Add_Time__c;
+            }
             addAppt.Appointment_Category__c = appt.Appointment_Category__c;
             addAppt.Appointment_Type__c = appt.Appointment_Type__c;
             addAppt.Appointment_Detail__c = appt.Description__c;

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -29,7 +29,6 @@ public with sharing class SummitEventsRegisterController {
     public Boolean showLocation { get; set; }
     public String startTimeString { get; set; }
     public String endTimeString { get; set; }
-    public Boolean adminOpen { get; set; }
     public String registrantAudience { get; set; }
     public String EvtUserType { get; set; }
     public Id incomingEventRegistrationId { get; set; }
@@ -163,12 +162,7 @@ public with sharing class SummitEventsRegisterController {
                 }
             }
 
-            if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                eventIsClosed = adminOpen;
-            } else {
-                eventIsClosed = SeaShared.isEventClosed(evtInstance);
-            }
+            eventIsClosed = SeaShared.isEventClosed(evtInstance);
 
             if (
                     (String.isNotBlank(eventPage.Add_Info_Question_Type_1__c) && String.isNotBlank(eventPage.Add_Info_Question_Text_1__c)) ||

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -277,14 +277,16 @@ public with sharing class SummitEventsRegisterController {
                 eventRegistration.Event_Website_Referrer__c = ApexPages.currentPage().getHeaders().get('Referer').replace('\'', '').escapeHtml4();
             }
 
+            //get and sanitize utm variables
             List<String> analyticCodes = new List<String>{
                     'gclid__c', 'utm_campaign__c', 'utm_content__c', 'utm_creative_format__c', 'utm_id__c',
                     'utm_marketing_tactic__c', 'utm_medium__c', 'utm_source__c', 'utm_source_platform__c', 'utm_term__c'
             };
 
             for (String code : analyticCodes) {
-                if (String.isNotBlank(ApexPages.currentPage().getParameters().get(code))) {
-                    String codeValue = ApexPages.currentPage().getParameters().get(code);
+                String urlParameter = code.removeEnd('__c');
+                if (String.isNotBlank(ApexPages.currentPage().getParameters().get(urlParameter))) {
+                    String codeValue = ApexPages.currentPage().getParameters().get(urlParameter);
                     codeValue = codeValue.replace('\'', '');
                     codeValue = codeValue.escapeHtml4();
                     eventRegistration.put(code, codeValue);

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -570,7 +570,7 @@ public with sharing class SummitEventsRegisterController {
             if (appt.Auto_Confirm_Appointment__c) {
                 addAppt.Appointment_Status__c = 'Confirmed';
             } else {
-                addAppt.Appointment_Status__c = 'Registered';
+                addAppt.Appointment_Status__c = 'Requested';
             }
             if (String.isNotBlank(appt.Auto_add_building__c)) {
                 addAppt.Building__c = appt.Auto_add_building__c;

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -14,7 +14,6 @@ public with sharing class SummitEventsRegisterGuestsController {
     public Map<Id, Summit_Events_Question__c> eventGuestQuestions { get; set; }
     public String templateSelected { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public Map<String, PageReference> pageFlow { get; set; }
     public String guestJSON { get; set; }
     public String guestQuestionJSON { get; set; }
@@ -165,12 +164,8 @@ public with sharing class SummitEventsRegisterGuestsController {
             pageFlow = seaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
             templateSelected = seaShared.getTemplate(eventPage.Template__c);
 
-            if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                eventIsClosed = adminOpen;
-            } else {
-                eventIsClosed = seaShared.isEventClosed(eventInstance);
-            }
+            eventIsClosed = seaShared.isEventClosed(eventInstance);
+
             formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
 
         }

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -169,7 +169,7 @@ public with sharing class SummitEventsRegisterGuestsController {
                 adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                 eventIsClosed = adminOpen;
             } else {
-                eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
+                eventIsClosed = seaShared.isEventClosed(eventInstance);
             }
             formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
 

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -60,7 +60,8 @@ public with sharing class SummitEventsRegisterGuestsController {
                     SELECT Event_Name__c, Event_Submit_Title__c, Event_Submit_Description__c, Event_Footer__c, Template__c, Event_Home_Link_Title__c, Event_Home_Link_URL__c,
                             Tracking_Submit_Registration__c, Event_Full_Text__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
                             Guest_Registration_Title__c, Guest_Max_Amount__c, Guest_Registration_Description__c, Guest_Table_Size__c, Guest_Tables_Available__c,
-                            Display_Guest_Registration__c, Guest_Registration_Add_Button_Label__c, No_Guest_Registrations_Added_Message__c
+                            Display_Guest_Registration__c, Guest_Registration_Add_Button_Label__c, No_Guest_Registrations_Added_Message__c,
+                            Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls-meta.xml
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SummitEventsRegistration.cls
+++ b/force-app/main/default/classes/SummitEventsRegistration.cls
@@ -76,8 +76,10 @@ public class SummitEventsRegistration {
                         }
                     } else if (em.Action_Status__c.equals(areg.Status__c) && String.isBlank(em.Action_Sub_status__c) && String.isBlank(areg.Substatus__c)) {
                         statusMatch = true;
-                        if (areg.BCC_Transactional_Email_Statuses__c.contains(em.Action_Status__c)) {
-                            bccRegStatusMatch = true;
+                        if (String.isNotBlank(areg.BCC_Transactional_Email_Statuses__c)) {
+                            if (areg.BCC_Transactional_Email_Statuses__c.contains(em.Action_Status__c)) {
+                                bccRegStatusMatch = true;
+                            }
                         }
                     }
 
@@ -85,6 +87,7 @@ public class SummitEventsRegistration {
                     BCCsToGo = addToEmailList(em.BCC_Email__c, BCCsToGo);
                     BCCsToGo = addToEmailList(areg.Registrant_Other_Email__c, BCCsToGo);
                     BCCsToGo = addToEmailList(areg.Registrant_Parent_Email__c, BCCsToGo);
+                    System.debug('bcc status match: ' + bccRegStatusMatch);
                     if (bccRegStatusMatch) {
                         BCCsToGo = addToEmailList(areg.BCC_Transactional_Emails__c, BCCsToGo);
                     }
@@ -143,7 +146,7 @@ public class SummitEventsRegistration {
                         originalTemplate = originalTemplate.replaceAll('\\[\\[DONT_DELETE_CONTENT_HERE\\]\\]', emailContent);
 
                         //send the message
-                        sendEmail2(areg.Registrant_Email__c, originalTemplate, emailContent, em.Email_Subject__c, em.Org_Email_Id__c, em.BCC_Email__c);
+                        sendEmail2(areg.Registrant_Email__c, originalTemplate, emailContent, em.Email_Subject__c, em.Org_Email_Id__c, BCCsToGo);
 
                         //Create an activity task
                         Task nt = new Task();
@@ -218,20 +221,14 @@ public class SummitEventsRegistration {
         return res;
     }
 
-    public static void sendEmail2(String EmailTo, String HTMLBody, String plainBody, String Subject, Id OrgEmailId, String BCCString) {
+    public static void sendEmail2(String EmailTo, String HTMLBody, String plainBody, String Subject, Id OrgEmailId, List<String> BccList) {
         Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
         mail.setToAddresses(new String[]{
                 EmailTo
         });
+        System.debug(BccList);
         mail.setSubject(Subject);
-        if (!String.isBlank(BCCString)) {
-            BCCString = BCCString.replaceAll('\\s+', '');
-            BCCString = BCCString.replaceAll(';', ',');
-            List<String> bccList = BCCString.split(',');
-            if (bccList.size() > 0) {
-                mail.setBccAddresses(bccList);
-            }
-        }
+        mail.setBccAddresses(bccList);
         mail.setPlainTextBody(plainBody);
         if (String.isBlank(HTMLBody)) {
             mail.setHtmlBody(plainBody);

--- a/force-app/main/default/classes/SummitEventsRegistration.cls
+++ b/force-app/main/default/classes/SummitEventsRegistration.cls
@@ -145,7 +145,7 @@ public class SummitEventsRegistration {
                         originalTemplate = originalTemplate.replaceAll('\\[\\[DONT_DELETE_CONTENT_HERE\\]\\]', emailContent);
 
                         //send the message
-                        sendEmail2(areg.Registrant_Email__c, originalTemplate, emailContent, em.Email_Subject__c, em.Org_Email_Id__c, BCCsToGo);
+                        String emailMessage = sendEmail2(areg.Registrant_Email__c, originalTemplate, emailContent, em.Email_Subject__c, em.Org_Email_Id__c, BCCsToGo);
 
                         //Create an activity task
                         Task nt = new Task();
@@ -160,6 +160,7 @@ public class SummitEventsRegistration {
                         nt.Description = emailContent.replaceAll('</p>', '\n'); // Replaces </p> (the paragraph closing tag) with a line break, since it is functionally identical to a line break
                         nt.Description = nt.Description.replaceAll('<(.*?)>', ''); // Replaces angled brackets and everything between with an empty string
                         nt.Description += '\n\n' + 'Registrant Email: ' + areg.Registrant_Email__c;
+                        nt.Description = emailMessage + '\n\n' + nt.Description;
 
                         activityUpdates.add(nt);
                     }
@@ -167,7 +168,6 @@ public class SummitEventsRegistration {
                 }
             }
         }
-
 
         if (activityUpdates.size() > 0) {
             doCRUD crudToDo = new doCRUD();
@@ -220,23 +220,30 @@ public class SummitEventsRegistration {
         return res;
     }
 
-    public static void sendEmail2(String EmailTo, String HTMLBody, String plainBody, String Subject, Id OrgEmailId, List<String> BccList) {
-        Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
-        mail.setToAddresses(new String[]{
-                EmailTo
-        });
-        mail.setSubject(Subject);
-        mail.setBccAddresses(bccList);
-        mail.setPlainTextBody(plainBody);
-        if (String.isBlank(HTMLBody)) {
-            mail.setHtmlBody(plainBody);
-        } else {
-            mail.setHtmlBody(HTMLBody);
+    public static String sendEmail2(String EmailTo, String HTMLBody, String plainBody, String Subject, Id OrgEmailId, List<String> BccList) {
+        String emailMessage = 'Email successfully sent!';
+        try {
+            Messaging.SingleEmailMessage mail = new Messaging.SingleEmailMessage();
+            mail.setToAddresses(new String[]{
+                    EmailTo
+            });
+            mail.setSubject(Subject);
+            mail.setBccAddresses(bccList);
+            mail.setPlainTextBody(plainBody);
+            if (String.isBlank(HTMLBody)) {
+                mail.setHtmlBody(plainBody);
+            } else {
+                mail.setHtmlBody(HTMLBody);
+            }
+            mail.setOrgWideEmailAddressId(OrgEmailId);
+            Messaging.SendEmailResult [] r = Messaging.sendEmail(new Messaging.SingleEmailMessage[]{
+                    mail
+            });
+        } catch (Exception ex) {
+            emailMessage = 'Email failed with this error: ' + ex.getMessage();
+            System.debug(ex.getMessage());
         }
-        mail.setOrgWideEmailAddressId(OrgEmailId);
-        Messaging.SendEmailResult [] r = Messaging.sendEmail(new Messaging.SingleEmailMessage[]{
-                mail
-        });
+        return emailMessage;
     }
 
     private without sharing class doCRUD {

--- a/force-app/main/default/classes/SummitEventsRegistration.cls
+++ b/force-app/main/default/classes/SummitEventsRegistration.cls
@@ -64,17 +64,29 @@ public class SummitEventsRegistration {
             //Loop through gather email templates to get template and use registration fields to fill in hooks
             for (Summit_Events_Email__c em : matchEmail) {
                 Boolean statusMatch = false;
-
+                Boolean bccRegStatusMatch = false;
+                List<String> BCCsToGo = new List<String>();
                 if (em.Event__c.equals(areg.Event__c)) {
 
                     statusMatch = false;
 
-                    if (!String.isBlank(em.Action_Sub_status__c) && !String.isBlank(areg.Substatus__c)) {
+                    if (String.isNotBlank(em.Action_Sub_status__c) && String.isNotBlank(areg.Substatus__c)) {
                         if (em.Action_Sub_status__c.equals(areg.Substatus__c) && em.Action_Status__c.equalsIgnoreCase(areg.Status__c)) {
                             statusMatch = true;
                         }
                     } else if (em.Action_Status__c.equals(areg.Status__c) && String.isBlank(em.Action_Sub_status__c) && String.isBlank(areg.Substatus__c)) {
                         statusMatch = true;
+                        if (areg.BCC_Transactional_Email_Statuses__c.contains(em.Action_Status__c)) {
+                            bccRegStatusMatch = true;
+                        }
+                    }
+
+                    //Build the BCC list. No duplicate emails. Split strings.
+                    BCCsToGo = addToEmailList(em.BCC_Email__c, BCCsToGo);
+                    BCCsToGo = addToEmailList(areg.Registrant_Other_Email__c, BCCsToGo);
+                    BCCsToGo = addToEmailList(areg.Registrant_Parent_Email__c, BCCsToGo);
+                    if (bccRegStatusMatch) {
+                        BCCsToGo = addToEmailList(areg.BCC_Transactional_Emails__c, BCCsToGo);
                     }
 
                     if (statusMatch) {
@@ -159,6 +171,51 @@ public class SummitEventsRegistration {
             doCRUD crudToDo = new doCRUD();
             crudToDo.savTask(activityUpdates);
         }
+    }
+
+    /*
+    This method makes sure no duplicate emails make it into our lists causing BCC failures.
+    emailList is the list you want to maintain and emailIn is the new emails you want to add.
+     */
+    public static List<String> addToEmailList(String emailsInString, List<String> emailList) {
+        if (String.isNotBlank(emailsInString)) {
+            List<String> emailsIn = splitEmails(emailsInString);
+            for (String email : emailsIn) {
+                if (!emailList.contains(email)) {
+                    emailList.add(email);
+                }
+            }
+        }
+        return emailList;
+    }
+
+    public static List<String> splitEmails(String emailDelineatedString) {
+        List<String> checkedEmails = new List<String>();
+        if (String.isNotBlank(emailDelineatedString)) {
+            emailDelineatedString = emailDelineatedString.replaceAll('\\s+', ',');
+            emailDelineatedString = emailDelineatedString.replaceAll(';', ',');
+            List<String> emailList = emailDelineatedString.split(',');
+            for (String em : emailList) {
+                if (validateEmail(em)) {
+                    checkedEmails.add(em);
+                }
+            }
+        }
+        return checkedEmails;
+    }
+
+    public static Boolean validateEmail(String email) {
+        Boolean res = false;
+        if (String.isNotBlank(email)) {
+            // source: http://www.regular-expressions.info/email.html
+            String emailRegex = '^[a-zA-Z0-9._|\\\\%#~`=?&/$^*!}{+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}$';
+            Pattern MyPattern = Pattern.compile(emailRegex);
+            Matcher MyMatcher = MyPattern.matcher(email);
+            if (MyMatcher.matches()) {
+                res = true;
+            }
+        }
+        return res;
     }
 
     public static void sendEmail2(String EmailTo, String HTMLBody, String plainBody, String Subject, Id OrgEmailId, String BCCString) {

--- a/force-app/main/default/classes/SummitEventsRegistration.cls
+++ b/force-app/main/default/classes/SummitEventsRegistration.cls
@@ -87,7 +87,6 @@ public class SummitEventsRegistration {
                     BCCsToGo = addToEmailList(em.BCC_Email__c, BCCsToGo);
                     BCCsToGo = addToEmailList(areg.Registrant_Other_Email__c, BCCsToGo);
                     BCCsToGo = addToEmailList(areg.Registrant_Parent_Email__c, BCCsToGo);
-                    System.debug('bcc status match: ' + bccRegStatusMatch);
                     if (bccRegStatusMatch) {
                         BCCsToGo = addToEmailList(areg.BCC_Transactional_Emails__c, BCCsToGo);
                     }
@@ -226,7 +225,6 @@ public class SummitEventsRegistration {
         mail.setToAddresses(new String[]{
                 EmailTo
         });
-        System.debug(BccList);
         mail.setSubject(Subject);
         mail.setBccAddresses(bccList);
         mail.setPlainTextBody(plainBody);

--- a/force-app/main/default/classes/SummitEventsRegistration.cls-meta.xml
+++ b/force-app/main/default/classes/SummitEventsRegistration.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -395,25 +395,21 @@ public with sharing class SummitEventsShared {
         return '';
     }
 
-    public Boolean isEventClosed(Summit_Events__c eventPage, Summit_Events_Instance__c evtInstance) {
+    public Boolean isEventClosed(Summit_Events_Instance__c evtInstance) {
         //Figure out if the event is closed.
         Boolean eventIsClosed = false;
-
         Date compareCloseDate = Date.today();
+        //Get time in timezone fo event
+        DateTime dt = DateTime.now();
+        String timeZonePick = getTimeZonePick(evtInstance.Instance_Time_Zone__c);
+        TimeZone tz = getTimeZone(timeZonePick);
+        dt = dt.addSeconds((tz.getOffset(dt) / 1000));
+        Time compareCloseTime = dt.time();
 
-        if (eventPage.Close_Event_Days_Before__c != null && eventPage.Close_Event_Days_Before__c != 0) {
-            compareCloseDate = compareCloseDate.addDays((Integer.valueOf(eventPage.Close_Event_Days_Before__c) + 1));
-        }
-
-        Time compareCloseTime = System.now().time();
-
-        if (eventPage.Keep_Registration_Open_During_Event__c) {
-            if (evtInstance.Registration_Close_Date__c < compareCloseDate ||
-                    (evtInstance.Registration_Close_Date__c == compareCloseDate && evtInstance.Registration_Close_Time__c <= compareCloseTime)) {
+        if (evtInstance.Registration_Close_Date__c <= compareCloseDate) {
+            if(evtInstance.Registration_Close_Time__c < compareCloseTime) {
                 eventIsClosed = true;
             }
-        } else if (evtInstance.Registration_Close_Date__c <= compareCloseDate) {
-            eventIsClosed = true;
         }
 
         if (evtInstance.Current_Available_Capacity__c <= 0 || evtInstance.Active_Status__c != 'Active') {
@@ -579,7 +575,7 @@ public with sharing class SummitEventsShared {
     }
 
     public String removeHTMLandEscape(String incomingString, Boolean escapeHTML) {
-        if(String.isNotBlank(incomingString)) {
+        if (String.isNotBlank(incomingString)) {
             incomingString = incomingString.replaceAll('<[^>]+>', '').trim();
             if (escapeHTML) {
                 incomingString = incomingString.escapeHtml4();

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -395,25 +395,45 @@ public with sharing class SummitEventsShared {
         return '';
     }
 
+    public Boolean isBoolean(String booleanString) {
+        Boolean b;
+        booleanString = booleanString.toLowerCase();
+        if (booleanString == 'true') {
+            b = true;
+        } else if (booleanString == 'false') {
+            b = false;
+        } else if (booleanString == '0') {
+            b = false;
+        } else if (booleanString == '1') {
+            b = true;
+        }
+        return b;
+    }
+
     public Boolean isEventClosed(Summit_Events_Instance__c evtInstance) {
         // Figure out if the event is closed.
         Boolean eventIsClosed = false;
-        Date compareCloseDate = Date.today();
-        // Get time in timezone fo event
-        DateTime dt = DateTime.now();
-        String timeZonePick = getTimeZonePick(evtInstance.Instance_Time_Zone__c);
-        TimeZone tz = getTimeZone(timeZonePick);
-        dt = dt.addSeconds((tz.getOffset(dt) / 1000));
-        Time compareCloseTime = dt.time();
+        if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
+            Boolean adminOpen = isBoolean(ApexPages.currentPage().getParameters().get('adminopen'));
+            eventIsClosed = !adminOpen;
+        } else {
+            Date compareCloseDate = Date.today();
+            // Get time in timezone fo event
+            Datetime dt = Datetime.now();
+            String timeZonePick = getTimeZonePick(evtInstance.Instance_Time_Zone__c);
+            TimeZone tz = getTimeZone(timeZonePick);
+            dt = dt.addSeconds((tz.getOffset(dt) / 1000));
+            Time compareCloseTime = dt.time();
 
-        if (evtInstance.Registration_Close_Date__c <= compareCloseDate) {
-            if(evtInstance.Registration_Close_Time__c < compareCloseTime) {
+            if (evtInstance.Registration_Close_Date__c <= compareCloseDate) {
+                if (evtInstance.Registration_Close_Time__c < compareCloseTime) {
+                    eventIsClosed = true;
+                }
+            }
+
+            if (evtInstance.Current_Available_Capacity__c <= 0 || evtInstance.Active_Status__c != 'Active') {
                 eventIsClosed = true;
             }
-        }
-
-        if (evtInstance.Current_Available_Capacity__c <= 0 || evtInstance.Active_Status__c != 'Active') {
-            eventIsClosed = true;
         }
 
         return eventIsClosed;

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -396,10 +396,10 @@ public with sharing class SummitEventsShared {
     }
 
     public Boolean isEventClosed(Summit_Events_Instance__c evtInstance) {
-        //Figure out if the event is closed.
+        // Figure out if the event is closed.
         Boolean eventIsClosed = false;
         Date compareCloseDate = Date.today();
-        //Get time in timezone fo event
+        // Get time in timezone fo event
         DateTime dt = DateTime.now();
         String timeZonePick = getTimeZonePick(evtInstance.Instance_Time_Zone__c);
         TimeZone tz = getTimeZone(timeZonePick);

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -48,7 +48,8 @@ public with sharing class SummitEventsSubmitController {
                     SELECT Event_Name__c, Event_Submit_Title__c, Event_Submit_Description__c, Event_Footer__c, Template__c, Event_Home_Link_Title__c, Event_Home_Link_URL__c,
                             Tracking_Submit_Registration__c, Event_Full_Text__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
                             Donation_Description__c, Display_Optional_Donation__c, Payment_Gateway__c, Event_Fee_Label__c, Event_Fee_Total_Label__c,
-                            Event_Fee_Submit_List_Label__c, Payment_Button_Label__c, Event_Appointment_Submit_List_Label__c, Event_Guest_Submit_List_Label__c
+                            Event_Fee_Submit_List_Label__c, Payment_Button_Label__c, Event_Appointment_Submit_List_Label__c, Event_Guest_Submit_List_Label__c,
+                            Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -48,7 +48,7 @@ public with sharing class SummitEventsSubmitController {
                     SELECT Event_Name__c, Event_Submit_Title__c, Event_Submit_Description__c, Event_Footer__c, Template__c, Event_Home_Link_Title__c, Event_Home_Link_URL__c,
                             Tracking_Submit_Registration__c, Event_Full_Text__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
                             Donation_Description__c, Display_Optional_Donation__c, Payment_Gateway__c, Event_Fee_Label__c, Event_Fee_Total_Label__c,
-                            Event_Fee_Submit_List_Label__c, Payment_Button_Label__c
+                            Event_Fee_Submit_List_Label__c, Payment_Button_Label__c, Event_Appointment_Submit_List_Label__c, Event_Guest_Submit_List_Label__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -77,7 +77,7 @@ public with sharing class SummitEventsSubmitController {
                 adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
                 eventIsClosed = adminOpen;
             } else {
-                eventIsClosed = seaShared.isEventClosed(eventPage, eventInstance);
+                eventIsClosed = seaShared.isEventClosed(eventInstance);
             }
 
             if (String.isNotBlank(ApexPages.currentPage().getParameters().get('error'))) {

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -14,7 +14,6 @@ public with sharing class SummitEventsSubmitController {
     public Map <String, String> feesByIndex { get; set; }
     public String formattedNavDate { get; set; }
     public Boolean eventIsClosed { get; set; }
-    public Boolean adminOpen { get; set; }
     public List<Summit_Events_Fee__c> eventFees { get; set; }
     public Double totalPaymentAmount { get; set; }
     public Double existingPaymentAmount { get; set; }
@@ -73,12 +72,7 @@ public with sharing class SummitEventsSubmitController {
 
             pageFlow = seaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
 
-            if (String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
-                adminOpen = Boolean.valueOf(ApexPages.currentPage().getParameters().get('adminopen'));
-                eventIsClosed = adminOpen;
-            } else {
-                eventIsClosed = seaShared.isEventClosed(eventInstance);
-            }
+            eventIsClosed = seaShared.isEventClosed(eventInstance);
 
             if (String.isNotBlank(ApexPages.currentPage().getParameters().get('error'))) {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, ApexPages.currentPage().getParameters().get('error')));

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -1767,6 +1767,16 @@
                 <identifier>record_item_088</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Guest_Submit_List_Label__c</fieldItem>
+                <identifier>RecordEvent_Guest_Submit_List_Label_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-7f64a50a-6644-4f6c-b669-2baad4862426</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -1979,6 +1989,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Event_Appointment_Next_Instructions__c</fieldItem>
                 <identifier>RecordEvent_Appointment_Next_Instructions_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Appointment_Submit_List_Label__c</fieldItem>
+                <identifier>RecordEvent_Appointment_Submit_List_Label_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-24795d7b-a1f2-4663-956d-4f3d23a64a82</name>

--- a/force-app/main/default/layouts/Summit_Events_Appointment_Type__c-Summit Events Appointment Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Appointment_Type__c-Summit Events Appointment Default Layout.layout-meta.xml
@@ -26,6 +26,14 @@
                 <field>Appointment_Type_Status__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Appointment_Category__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Appointment_Type__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Required</behavior>
                 <field>Sort_Order__c</field>
             </layoutItems>
@@ -210,7 +218,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8H000001PCxD</masterLabel>
+        <masterLabel>00hDS000009Tzsm</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events_Question__c-Summit Events Question Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Question__c-Summit Events Question Layout.layout-meta.xml
@@ -62,6 +62,10 @@
                 <behavior>Edit</behavior>
                 <field>Display_Order__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Display_Style__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>
     </layoutSections>
@@ -193,7 +197,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h0R000007M7wn</masterLabel>
+        <masterLabel>00h7g000003dRZD</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
@@ -617,6 +617,65 @@
     <layoutSections>
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Analytics</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Website__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Website_Referrer__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>gclid__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_campaign__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_content__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_creative_format__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_id__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_marketing_tactic__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_medium__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_source__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_source_platform__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>utm_term__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsLeftToRight</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
         <editHeading>false</editHeading>
         <label>System Information</label>
         <layoutColumns>
@@ -712,7 +771,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hDS000008skK7</masterLabel>
+        <masterLabel>00h7g000003dRZE</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Registration__c-Summit Events Registration Default Layout.layout-meta.xml
@@ -42,6 +42,17 @@
                 <behavior>Edit</behavior>
                 <field>Actual_Number_of_Guests__c</field>
             </layoutItems>
+            <layoutItems>
+                <emptySpace>true</emptySpace>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>BCC_Transactional_Emails__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>BCC_Transactional_Email_Statuses__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/Summit_Events_Question__c/fields/Display_Style__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Question__c/fields/Display_Style__c.field-meta.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Display_Style__c</fullName>
+    <description>This setting determines how much room the question will take on the page. All questions are full width in mobile views.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>How much page space will this question take.</inlineHelpText>
+    <label>Display Style</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Full width</fullName>
+                <default>false</default>
+                <label>Full width</label>
+            </value>
+            <value>
+                <fullName>Half width</fullName>
+                <default>false</default>
+                <label>Half width</label>
+            </value>
+            <value>
+                <fullName>Third width</fullName>
+                <default>false</default>
+                <label>Third width</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/BCC_Transactional_Email_Statuses__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/BCC_Transactional_Email_Statuses__c.field-meta.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BCC_Transactional_Email_Statuses__c</fullName>
+    <description>Selected status will send transactional emails to the BCC Transactional Emails list if those status emails have been defined for the event.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Selected status will send transactional emails to the BCC Transactional Emails list if those status emails have been defined for the event.</inlineHelpText>
+    <label>BCC Transactional Email Statuses</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>MultiselectPicklist</type>
+    <valueSet>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>Started</fullName>
+                <default>false</default>
+                <label>Started</label>
+            </value>
+            <value>
+                <fullName>Registered</fullName>
+                <default>false</default>
+                <label>Registered</label>
+            </value>
+            <value>
+                <fullName>In Progress</fullName>
+                <default>false</default>
+                <label>In Progress</label>
+            </value>
+            <value>
+                <fullName>Confirmed</fullName>
+                <default>false</default>
+                <label>Confirmed</label>
+            </value>
+            <value>
+                <fullName>Attended</fullName>
+                <default>false</default>
+                <label>Attended</label>
+            </value>
+            <value>
+                <fullName>Cancelled</fullName>
+                <default>false</default>
+                <label>Cancelled</label>
+            </value>
+            <value>
+                <fullName>Rescheduled</fullName>
+                <default>false</default>
+                <label>Rescheduled</label>
+            </value>
+            <value>
+                <fullName>No-Show</fullName>
+                <default>false</default>
+                <label>No-Show</label>
+            </value>
+        </valueSetDefinition>
+    </valueSet>
+    <visibleLines>4</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/BCC_Transactional_Emails__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/BCC_Transactional_Emails__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>BCC_Transactional_Emails__c</fullName>
+    <description>Comma separated email list to send transactional emails for this registration.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Comma separated email list to send transactional emails for this registration.</inlineHelpText>
+    <label>BCC Transactional Emails</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>TextArea</type>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website_Referrer__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website_Referrer__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Website_Referrer__c</fullName>
+    <description>The page the user was at just before landing on the Event Registration form page.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The page the user was at just before landing on the Event Registration form page.</inlineHelpText>
+    <label>Event Website Referrer</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Url</type>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website_Referrer__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website_Referrer__c.field-meta.xml
@@ -5,8 +5,9 @@
     <externalId>false</externalId>
     <inlineHelpText>The page the user was at just before landing on the Event Registration form page.</inlineHelpText>
     <label>Event Website Referrer</label>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Url</type>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website__c.field-meta.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Website__c</fullName>
+    <description>Website which registration occurs.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Website which registration occurs.</inlineHelpText>
     <label>Event Website</label>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Url</type>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Website__c.field-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Website__c</fullName>
+    <externalId>false</externalId>
+    <label>Event Website</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Url</type>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/gclid__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/gclid__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>gclid__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>gclid</label>
-    <length>255</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/gclid__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/gclid__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>gclid__c</fullName>
+    <externalId>false</externalId>
+    <label>gclid</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_campaign__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_campaign__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_campaign__c</fullName>
+    <externalId>false</externalId>
+    <label>utm campaign</label>
+    <length>100</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_campaign__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_campaign__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_campaign__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm campaign</label>
-    <length>100</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_content__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_content__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_content__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm content</label>
-    <length>100</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_content__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_content__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_content__c</fullName>
+    <externalId>false</externalId>
+    <label>utm content</label>
+    <length>100</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_creative_format__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_creative_format__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_creative_format__c</fullName>
+    <externalId>false</externalId>
+    <label>utm creative format</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_creative_format__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_creative_format__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_creative_format__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm creative format</label>
-    <length>255</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_id__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_id__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_id__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm Id</label>
-    <length>255</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_id__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_id__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_id__c</fullName>
+    <externalId>false</externalId>
+    <label>utm Id</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_marketing_tactic__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_marketing_tactic__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_marketing_tactic__c</fullName>
+    <externalId>false</externalId>
+    <label>utm marketing tactic</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_marketing_tactic__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_marketing_tactic__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_marketing_tactic__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm marketing tactic</label>
-    <length>255</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_medium__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_medium__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_medium__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm medium</label>
-    <length>100</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_medium__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_medium__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_medium__c</fullName>
+    <externalId>false</externalId>
+    <label>utm medium</label>
+    <length>100</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_source__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm source</label>
-    <length>100</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_source__c</fullName>
+    <externalId>false</externalId>
+    <label>utm source</label>
+    <length>100</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source_platform__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source_platform__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_source_platform__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm source platform</label>
-    <length>255</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source_platform__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_source_platform__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_source_platform__c</fullName>
+    <externalId>false</externalId>
+    <label>utm source platform</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_term__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_term__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>utm_term__c</fullName>
+    <description>Analytic url parameter.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Analytic url parameter.</inlineHelpText>
     <label>utm term</label>
-    <length>100</length>
-    <required>false</required>
+    <length>2000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>2</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_term__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/utm_term__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>utm_term__c</fullName>
+    <externalId>false</externalId>
+    <label>utm term</label>
+    <length>100</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Ask_Phone__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Ask_Phone__c.field-meta.xml
@@ -43,6 +43,16 @@
                 <default>false</default>
                 <label>Ask home and mobile require both</label>
             </value>
+            <value>
+                <fullName>Ask mobile</fullName>
+                <default>false</default>
+                <label>Ask mobile</label>
+            </value>
+            <value>
+                <fullName>Ask mobile and require</fullName>
+                <default>false</default>
+                <label>Ask mobile and require</label>
+            </value>
         </valueSetDefinition>
     </valueSet>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Appointment_Submit_List_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Appointment_Submit_List_Label__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Appointment_Submit_List_Label__c</fullName>
+    <description>Appears on the submit page as title to itemized list of Appointments. Defaults to &quot;Selected options&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Selected options&quot;</inlineHelpText>
+    <label>Event Appointment Submit List Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Guest_Submit_List_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Guest_Submit_List_Label__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Guest_Submit_List_Label__c</fullName>
+    <description>Appears on the submit page as title to itemized list of Guests. Defaults to &quot;Additional guests registred&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Additional guests registred&quot;</inlineHelpText>
+    <label>Event Guest Submit List Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
+++ b/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
@@ -76,8 +76,7 @@
                     <apex:outputPanel rendered="{!!eventIsClosed && questionWrapper.size > 0}" layout="none">
                         <apex:variable var="qNum" value="{!0}"/>
                         <apex:repeat value="{!questionWrapper}" var="qu">
-
-                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 slds-error {!If(qu.type != 'Text Area','slds-large-size_3-of-6',false)}" rendered="{!qu.setupFail}">
+                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 slds-error {!qu.displayStyle}" rendered="{!qu.setupFail}">
                                 <apex:outputLabel styleClass="slds-form-element__label">
                                     {!qu.question}
                                     <apex:outputText escape="false" rendered="{!qu.required}">
@@ -87,7 +86,7 @@
                                 <p class="slds-text-color_error">{!qu.setupError}</p>
                             </apex:outputPanel>
 
-                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 {!If(qu.type != 'Text Area','slds-large-size_3-of-6',false)}" rendered="{!If(qu.type != 'Checkbox' && !qu.setupFail, true, false)}">
+                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 {!qu.displayStyle}" rendered="{!If(qu.type != 'Checkbox' && !qu.setupFail, true, false)}">
                                 <apex:outputPanel layout="block" styleClass="slds-form-element {!IF(qu.required, 'slds-is-required', '')}">
 
                                     <apex:outputLabel styleClass="slds-form-element__label">

--- a/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
+++ b/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
@@ -28,6 +28,16 @@
                     });
                 }
             </script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
+++ b/force-app/main/default/pages/SummitEventsAdditionalQuestions.page
@@ -29,14 +29,15 @@
                 }
             </script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/pages/SummitEventsCancelReview.page
+++ b/force-app/main/default/pages/SummitEventsCancelReview.page
@@ -15,16 +15,27 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="pageTitle"><a href="{!eventRegistration.Event__r.Event_Home_Link_URL__c}">{!eventRegistration.Event__r.Event_Home_Link_Title__c}</a></apex:define>
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
+            <script>
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
+                    'account': '{!IF(!ISBLANK(eventRegistration.Event__r.Account__r.Name),eventRegistration.Event__r.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventRegistration.Event__r.Audience__c),eventRegistration.Event__r.Audience__c, '')}',
+                    'eventLabel': '{!eventRegistration.Event__r.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventRegistration.Event__r.Filter_Category__c), eventRegistration.Event__r.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventRegistration.Event__r.Event_Sponsor__c), eventRegistration.Event__r.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                });
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">
             <div class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
-                <apex:messages />
+                <apex:messages/>
             </div>
             <apex:form id="SummitEventsRegistrationCancelReview" rendered="{!!eventOver && !eventNotFound && eventRegistration.Status__c != 'Cancelled'}" styleClass="slds-grid slds-wrap">
                 <div class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
                     <!-- EVENT BREADCRUMB -->
-                    <div class="slds-col slds-p-vertical-small slds-size_1-of-1">
+                    <div class="slds-col slds-size_1-of-1">
                         <nav role="navigation" aria-label="Breadcrumbs">
                             <ol class="slds-breadcrumb slds-list_horizontal">
                                 <apex:outputPanel rendered="{!!ISBLANK(eventPage.Event_Name__c)}" layout="none">
@@ -48,8 +59,8 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         <apex:outputText value="{!eventRegistration.Event__r.Event_Cancel_Review_Description__c}" escape="false"/>
                     </p>
                 </div>
-                <div id="reviewWrapper" class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
-                    <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">
+                <div id="reviewWrapper" class="slds-col slds-size_1-of-1 slds-p-vertical_x-small">
+                    <h3 class="slds-text-heading_medium slds-p-vertical_small">
                         <apex:outputText value="{!eventRegistration.Event__r.Name}"/>
                     </h3>
                     <p class="slds-text-body slds-p-vertical_xx-small regularLists">
@@ -67,7 +78,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         </apex:repeat>
                     </ul>
                     <apex:outputPanel layout="block" rendered="{!IF (evt.Status__c != 'Cancelled', true, false)}">
-                        <p class="slds-text-body slds-p-vertical_xx-small">
+                        <p class="slds-text-body slds-p-vertical_small">
                             <apex:commandLink action="{!cancelRegistration}" Value="Cancel Regisistration" id="cancelReg" onClick="return confirm('Are you sure you want to cancel this registration?');" styleClass="slds-button slds-button_brand slds-p-horizontal_xx-large slds-p-vertical_xx-small"/>
                         </p>
                     </apex:outputPanel>

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -16,14 +16,15 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -15,6 +15,16 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="pageTitle"><a href="{!eventPage.Event_Home_Link_URL__c}">{!eventPage.Event_Home_Link_Title__c}</a></apex:define>
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -48,7 +48,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         </h2>
                         <div class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
                             <p class="slds-text-body slds-p-vertical_xx-small">
-                                <apex:outputText value="{!eventPage.Event_Full_Text__c}"/>
+                                <apex:outputText escape="false" value="{!eventPage.Event_Full_Text__c}"/>
                             </p>
                         </div>
                     </apex:outputPanel>

--- a/force-app/main/default/pages/SummitEventsDonation.page
+++ b/force-app/main/default/pages/SummitEventsDonation.page
@@ -16,6 +16,16 @@ Created by Thaddaeus Dahlberg on 2/10/2020.
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/donation.js')}" type="text/javascript"></script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsDonation.page
+++ b/force-app/main/default/pages/SummitEventsDonation.page
@@ -17,14 +17,15 @@ Created by Thaddaeus Dahlberg on 2/10/2020.
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/donation.js')}" type="text/javascript"></script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -396,10 +396,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                             </apex:outputPanel>
 
                             <!-- MOBILE PHONE NUMBER -->
-                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 slds-large-size_3-of-6" rendered="{!IF(CONTAINS(eventPage.Ask_Phone__c, 'home and mobile') || phoneType == 'mobile' || (phoneType= '' && CONTAINS(eventPage.Ask_Phone__c, 'with type')), true, false)}">
-                                <div class="slds-form-element {!If(eventPage.Ask_Phone__c = 'Ask with type require' || eventPage.Ask_Phone__c = 'Ask home and mobile require both', 'slds-is-required', '')}">
+                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 slds-large-size_3-of-6"
+                                              rendered="{!IF(CONTAINS(eventPage.Ask_Phone__c, 'home and mobile') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' || phoneType == 'mobile' || (phoneType= '' && CONTAINS(eventPage.Ask_Phone__c, 'with type')), true, false)}">
+                                <div class="slds-form-element {!If(eventPage.Ask_Phone__c = 'Ask with type require' || eventPage.Ask_Phone__c = 'Ask home and mobile require both' || eventPage.Ask_Phone__c == 'Ask mobile and require', 'slds-is-required', '')}">
                                     <apex:outputLabel for="mobile" styleClass="slds-form-element__label">
-                                        {!IF((CONTAINS(eventPage.Ask_Phone__c, 'with type') && phoneType == ''),'', 'Mobile ')}{!eventPage.Phone_Label__c}
+                                        {!IF((CONTAINS(eventPage.Ask_Phone__c, 'with type') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' && phoneType == ''),'', 'Mobile ')}{!eventPage.Phone_Label__c}
                                         <apex:outputText escape="false" rendered="{!IF(CONTAINS(eventPage.Ask_Phone__c, 'require'), true, false)}">
                                             <abbr class="slds-required" title="required">*</abbr>
                                         </apex:outputText>
@@ -435,8 +436,8 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                             </apex:outputPanel>
 
                             <!-- TEXT MESSAGE ASK -->
-                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1" rendered="{!IF(CONTAINS(eventPage.Ask_Phone__c, 'mobile') || phoneType='mobile', true, false)}">
-                                <div class="slds-form-element slds-is-required">
+                            <apex:outputPanel layout="block" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1" rendered="{!IF(CONTAINS(eventPage.Ask_Phone__c, 'mobile') || eventPage.Ask_Phone__c == 'Ask mobile' || eventPage.Ask_Phone__c == 'Ask mobile and require' ||  phoneType='mobile', true, false)}">
+                                <div class="slds-form-element">
                                     <div class="slds-form-element__control">
                                         <div class="slds-checkbox">
                                             <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage"/>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -294,7 +294,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     {!eventPage.First_Name_Label__c} <abbr class="slds-required" title="required">*</abbr>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Registrant_First_Name__c}" html-aria-describedby="firstName-required" id="firstName" required="true" styleClass="slds-input {!IF(!contactSet,'required requiredText', '')} {!IF(contactSet, 'disable', '')}" disabled="{!contactSet}"/>
+                                    <apex:inputText value="{!eventRegistration.Registrant_First_Name__c}" html-aria-describedby="firstName-required" id="firstName" required="true" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_First_Name__c)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="firstName-required">This field is required</div>
                             </div>
@@ -307,7 +307,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     {!eventPage.Last_Name_Label__c} <abbr class="slds-required" title="required">*</abbr>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Registrant_Last_Name__c}" id="lastName" html-aria-describedby="lastName-required" required="true" styleClass="slds-input {!IF(contactSet, 'disable', '')}" disabled="{!contactSet}"/>
+                                    <apex:inputText value="{!eventRegistration.Registrant_Last_Name__c}" id="lastName" html-aria-describedby="lastName-required" required="true" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Last_Name__c)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="lastName-required">This field is required</div>
                             </div>
@@ -320,7 +320,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     {!eventPage.Email_Label__c} <abbr class="slds-required" title="required">*</abbr>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:input type="email" value="{!eventRegistration.Registrant_Email__c}" id="email" html-aria-describedby="email-required" required="true" styleClass="slds-input {!IF(!contactSet,'required requiredText validEmail', '')}" disabled="{!contactSet}"/>
+                                    <apex:input type="email" value="{!eventRegistration.Registrant_Email__c}" id="email" html-aria-describedby="email-required" required="true" styleClass="slds-input validEmail" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Email__c)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="email-required">This field is required</div>
                             </div>
@@ -336,7 +336,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Registrant_Preferred_First_Name__c}" id="preferredFirstName" html-aria-describedby="preferredFirstName-required" required="{!IF(eventPage.Ask_Preferred_First_Name__c == 'Ask and require', true, false)}" styleClass="slds-input {!IF(contactSet, 'disable', '')}" disabled="{!contactSet}"/>
+                                    <apex:inputText value="{!eventRegistration.Registrant_Preferred_First_Name__c}" id="preferredFirstName" html-aria-describedby="preferredFirstName-required" required="{!IF(eventPage.Ask_Preferred_First_Name__c == 'Ask and require', true, false)}" styleClass="slds-input"/>
                                 </div>
                                 <div class="slds-form-element__help" id="preferredFirstName-required">
                                     {!IF(eventPage.Ask_Preferred_First_Name__c == 'Ask and require', 'This field is required', '')}
@@ -353,7 +353,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Last_Name_as_Student__c}" html-aria-describedby="lastNameAsStudent-required" id="lastNameAsStudent" styleClass="slds-input {!IF(contactSet, 'disable', '')}" required="{!IF(eventPage.Ask_Last_Name_As_Student__c == 'Ask and require', true, false)}"/>
+                                    <apex:inputText value="{!eventRegistration.Last_Name_as_Student__c}" html-aria-describedby="lastNameAsStudent-required" id="lastNameAsStudent" styleClass="slds-input" required="{!IF(eventPage.Ask_Last_Name_As_Student__c == 'Ask and require', true, false)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="lastNameAsStudent-required">
                                     {!IF(eventPage.Ask_Last_Name_As_Student__c == 'Ask and require', 'This field is required', '')}
@@ -378,7 +378,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputText>
                                     </apex:outputLabel>
                                     <div class="slds-form-element__control">
-                                        <apex:input type="tel" value="{!eventRegistration.Registrant_Phone__c}" id="phone" html-aria-describedby="phone-required" disabled="{!contactSet}" styleClass="slds-input"/>
+                                        <apex:input type="tel" value="{!eventRegistration.Registrant_Phone__c}" id="phone" html-aria-describedby="phone-required" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Phone__c)}" styleClass="slds-input"/>
                                     </div>
                                     <div class="slds-form-element__help" id="phone-required">
                                         Phone required
@@ -396,7 +396,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputText>
                                     </apex:outputLabel>
                                     <div class="slds-form-element__control">
-                                        <apex:input type="tel" value="{!eventRegistration.Registrant_Mobile_Phone__c}" id="mobile" html-aria-describedby="mobile-required" disabled="{!contactSet}" styleClass="slds-input"/>
+                                        <apex:input type="tel" value="{!eventRegistration.Registrant_Mobile_Phone__c}" id="mobile" html-aria-describedby="mobile-required" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Mobile_Phone__c)}" styleClass="slds-input"/>
                                     </div>
                                     <div class="slds-form-element__help" id="mobile-required">
                                         {!IF(CONTAINS(eventPage.Ask_Phone__c, 'with type'),'', 'Mobile ')}phone required
@@ -430,7 +430,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <div class="slds-form-element slds-is-required">
                                     <div class="slds-form-element__control">
                                         <div class="slds-checkbox">
-                                            <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage" disabled="{!contactSet}"/>
+                                            <apex:inputCheckbox value="{!eventRegistration.Registrant_Receive_Texts__c}" id="AcceptTextMessage"/>
                                             <apex:outputLabel for="AcceptTextMessage" styleClass="slds-checkbox__label">
                                                 <span class="slds-checkbox_faux"></span>
                                                 <span class="slds-form-element__label">{!eventPage.Registrant_Receive_Texts_Label__c} <abbr class="slds-required" title="required">*</abbr></span>
@@ -452,7 +452,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
                                     <div class="slds-select_container">
-                                        <apex:selectList value="{!eventRegistration.Registrant_Gender__c}" size="1" id="Gender" multiselect="false" required="{!IF(eventPage.Ask_Gender__c == 'Ask and require', true, false)}" styleClass="slds-select {!IF(eventPage.Ask_Gender__c == 'Ask and require', 'required', '')}" disabled="{!contactSet}">
+                                        <apex:selectList value="{!eventRegistration.Registrant_Gender__c}" size="1" id="Gender" multiselect="false" required="{!IF(eventPage.Ask_Gender__c == 'Ask and require', true, false)}" styleClass="slds-select {!IF(eventPage.Ask_Gender__c == 'Ask and require', 'required', '')}">
                                             <apex:selectOptions value="{!sexDD}"/>
                                         </apex:selectList>
                                     </div>
@@ -471,7 +471,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
                                     <div class="slds-select_container">
-                                        <apex:selectList value="{!eventRegistration.Registrant_Pronouns__c}" size="1" id="pronoun" multiselect="false" required="{!IF(eventPage.Ask_Pronoun__c == 'Ask and require', true, false)}" styleClass="slds-select {!IF(eventPage.Ask_Pronoun__c == 'Ask and require', 'required', '')}" disabled="{!contactSet}">
+                                        <apex:selectList value="{!eventRegistration.Registrant_Pronouns__c}" size="1" id="pronoun" multiselect="false" required="{!IF(eventPage.Ask_Pronoun__c == 'Ask and require', true, false)}" styleClass="slds-select">
                                             <apex:selectOptions value="{!PronounDD}"/>
                                         </apex:selectList>
                                     </div>
@@ -489,7 +489,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Registrant_Title__c}" id="title" html-aria-describedby="title-required" required="{!IF(eventPage.Ask_Title__c == 'Ask and require', true, false)}" styleClass="slds-input {!IF(eventPage.Ask_Title__c == 'Ask and require', 'required', '')} {!IF(contactSet, 'disable', '')}"/>
+                                    <apex:inputText value="{!eventRegistration.Registrant_Title__c}" id="title" html-aria-describedby="title-required" required="{!IF(eventPage.Ask_Title__c == 'Ask and require', true, false)}" styleClass="slds-input {!IF(eventPage.Ask_Title__c == 'Ask and require', 'required', '')}"/>
                                 </div>
                             </div>
                         </apex:outputPanel>
@@ -504,7 +504,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:inputText value="{!eventRegistration.Registrant_Company_Organization__c}" id="companyorganization" html-aria-describedby="companyorganization" required="{!IF(eventPage.Ask_Company_Organization__c == 'Ask and require', true, false)}" styleClass="slds-input {!IF(eventPage.Ask_Company_Organization__c == 'Ask and require', 'required', '')} {!IF(contactSet, 'disable', '')}"/>
+                                    <apex:inputText value="{!eventRegistration.Registrant_Company_Organization__c}" id="companyorganization" html-aria-describedby="companyorganization" required="{!IF(eventPage.Ask_Company_Organization__c == 'Ask and require', true, false)}" styleClass="slds-input {!IF(eventPage.Ask_Company_Organization__c == 'Ask and require', 'required', '')}"/>
                                 </div>
                             </div>
                         </apex:outputPanel>
@@ -542,7 +542,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:input type="number" value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear {!IF(contactSet, 'disable', '')}" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
+                                    <apex:input type="number" value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="preferredClassYear-required">
                                     {!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', 'This field is required', '')}
@@ -560,7 +560,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:input type="date" value="{!eventRegistration.Registrant_Date_of_Birth__c}" id="dateOfBirth" html-aria-describedby="dateOfBirth-required" styleClass=" slds-input {!IF(!contactSet,'required requiredText', '')} mmddyyyy" disabled="{!contactSet}" required="{!IF(eventPage.Ask_Date_Of_Birth__c == 'Ask and require', true, false)}" html-placeholder="MM/DD/YYYY"/>
+                                    <apex:input type="date" value="{!eventRegistration.Registrant_Date_of_Birth__c}" id="dateOfBirth" html-aria-describedby="dateOfBirth-required" styleClass=" slds-input mmddyyyy" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Date_of_Birth__c)}" required="{!IF(eventPage.Ask_Date_Of_Birth__c == 'Ask and require', true, false)}" html-placeholder="MM/DD/YYYY"/>
                                 </div>
                                 <div class="slds-form-element__help" id="dateOfBirth-required">
                                     {!IF(eventPage.Ask_Date_Of_Birth__c == 'Ask and require', 'This field is required', '')}
@@ -609,7 +609,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputText>
                                     </apex:outputLabel>
                                     <div class="slds-form-element__control">
-                                        <apex:inputText value="{!eventRegistration.Registrant_Street_1__c}" id="street" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input {!IF(contactSet, 'disable', '')}"/>
+                                        <apex:inputText value="{!eventRegistration.Registrant_Street_1__c}" id="street" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Street_1__c)}"/>
                                     </div>
                                 </div>
                             </div>
@@ -618,7 +618,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <div class="slds-form-element">
                                     <apex:outputLabel value="Street Line 2 (Optional)" for="street2" styleClass="slds-form-element__label"/>
                                     <div class="slds-form-element__control">
-                                        <apex:inputText value="{!eventRegistration.Registrant_Street_2__c}" id="street2" styleClass="slds-input {!IF(contactSet, 'disable', '')}"/>
+                                        <apex:inputText value="{!eventRegistration.Registrant_Street_2__c}" id="street2" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Street_1__c)}"/>
                                     </div>
                                 </div>
                             </div>
@@ -633,7 +633,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputLabel>
                                         <div class="slds-form-element__control">
                                             <div class="slds-select_container">
-                                                <apex:selectList value="{!eventRegistration.Registrant_Country__c}" size="1" id="country" multiselect="false" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-select" disabled="{!contactSet}" onChange="setCountrySetting(this.value)">
+                                                <apex:selectList value="{!eventRegistration.Registrant_Country__c}" size="1" id="country" multiselect="false" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-select" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Country__c)}" onChange="setCountrySetting(this.value)">
                                                     <apex:selectOptions value="{!countryDD}"/>
                                                 </apex:selectList>
                                             </div>
@@ -651,7 +651,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                             </apex:outputText>
                                         </apex:outputLabel>
                                         <div class="slds-form-element__control">
-                                            <apex:inputText value="{!eventRegistration.Registrant_Zip__c}" id="zip" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input {!IF(!contactSet,'required requiredText', '')} {!IF(contactSet, 'disable', '')}"/>
+                                            <apex:inputText value="{!eventRegistration.Registrant_Zip__c}" id="zip" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_Zip__c)}"/>
                                         </div>
                                     </div>
                                 </div>
@@ -665,7 +665,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                             </apex:outputText>
                                         </apex:outputLabel>
                                         <div class="slds-form-element__control">
-                                            <apex:inputText value="{!eventRegistration.Registrant_City__c}" id="city" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input {!IF(!contactSet,'required requiredText', '')} {!IF(contactSet, 'disable', '')}"/>
+                                            <apex:inputText value="{!eventRegistration.Registrant_City__c}" id="city" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_City__c)}"/>
                                         </div>
                                     </div>
                                 </div>
@@ -680,12 +680,12 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputLabel>
                                         <div class="slds-form-element__control">
                                             <apex:outputPanel layout="block" styleClass="slds-select_container" rendered="{!stateDD.size > 0}">
-                                                <apex:selectList value="{!eventRegistration.Registrant_State__c}" size="1" id="state" multiselect="false" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-select {!IF(!contactSet,'required requiredText', '')}" disabled="{!contactSet}">
+                                                <apex:selectList value="{!eventRegistration.Registrant_State__c}" size="1" id="state" multiselect="false" required="{!IF(CONTAINS(eventPage.Ask_Mailing_Address__c, 'require'), true, false)}" styleClass="slds-select" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_State__c)}">
                                                     <apex:selectOptions value="{!stateDD}"/>
                                                 </apex:selectList>
                                             </apex:outputPanel>
                                             <apex:outputPanel layout="none" rendered="{!stateDD.size = 0}">
-                                                <apex:inputText value="{!eventRegistration.Registrant_State_Province__c}" id="stateProvince" required="false" styleClass="slds-input {!IF(contactSet, 'disable', '')}"/>
+                                                <apex:inputText value="{!eventRegistration.Registrant_State_Province__c}" id="stateProvince" required="false" styleClass="slds-input" disabled="{!contactSet && !ISBLANK(eventRegistration.Registrant_State_Province__c)}"/>
                                             </apex:outputPanel>
                                         </div>
                                     </div>
@@ -722,7 +722,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <apex:outputLabel value="Additional guests" for="guests" styleClass="slds-form-element__label"/>
                                     <div class="slds-form-element__control">
                                         <div class="slds-select_container">
-                                            <apex:selectList size="1" value="{!eventRegistration.Number_of_Guests__c}" id="guests" styleClass="slds-select {!IF(!contactSet,'required requiredText', '')}">
+                                            <apex:selectList size="1" value="{!eventRegistration.Number_of_Guests__c}" id="guests" styleClass="slds-select">
                                                 <apex:selectOptions value="{!guestAmt}"/>
                                             </apex:selectList>
                                         </div>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -30,7 +30,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="body">
             <div class="slds-grid slds-wrap" xmlns="http://www.w3.org/2000/svg" version="1.1">
                 <div class="slds-col slds-p-around_x-small slds-size_1-of-1">
-                    <apex:messages/>
+                    <apex:messages />
                 </div>
 
                 <apex:form id="SummitEventRegisterForm" styleClass="slds-grid slds-wrap" style="width:100%">

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -23,6 +23,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(evtInstance.Instance_Title__c),' - ' + evtInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
                 }];
             </script>
         </apex:define>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -16,6 +16,15 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/register.js')}" type="text/javascript"></script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(evtInstance.Instance_Title__c),' - ' + evtInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                }];
+            </script>
         </apex:define>
 
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -17,14 +17,15 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/register.js')}" type="text/javascript"></script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(evtInstance.Instance_Title__c),' - ' + evtInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
 

--- a/force-app/main/default/pages/SummitEventsRegisterAppointments.page
+++ b/force-app/main/default/pages/SummitEventsRegisterAppointments.page
@@ -21,7 +21,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="body">
             <div class="slds-grid slds-wrap" xmlns="http://www.w3.org/2000/svg" version="1.1">
                 <div class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
-                    <apex:messages />
+                    <apex:messages/>
                 </div>
 
                 <apex:form id="SummitEventsRegisterAppointmentsForm" styleClass="slds-grid slds-wrap">
@@ -107,7 +107,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                                         <textarea required="required" class="appointmentCustomInput required slds-textarea"></textarea>
                                                     </apex:outputPanel>
 
-                                                    <apex:outputPanel layout="none" rendered="{!apt.appInput == 'Custom pick list' || apt.appInput == 'Required custom pick list' || !ISBLANK(apt.appCategory)}">
+                                                    <apex:outputPanel layout="none" rendered="{!apt.appInput == 'Custom pick list' || apt.appInput == 'Required custom pick list' || !ISBLANK(apt.appCategory) && !ISNULL(apt.picklistItemList) && !apt.appTypeSet}">
                                                         <apex:outputPanel layout="none" rendered="{!apt.picklistItemList.size > 0}">
                                                             <div class="slds-select_container">
                                                                 <apex:outputPanel layout="none" rendered="{!apt.appRequired}">

--- a/force-app/main/default/pages/SummitEventsRegisterAppointments.page
+++ b/force-app/main/default/pages/SummitEventsRegisterAppointments.page
@@ -17,14 +17,15 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/options.js')}" type="text/javascript"></script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(evtInstance.Instance_Title__c),' - ' + evtInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/pages/SummitEventsRegisterAppointments.page
+++ b/force-app/main/default/pages/SummitEventsRegisterAppointments.page
@@ -21,7 +21,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="body">
             <div class="slds-grid slds-wrap" xmlns="http://www.w3.org/2000/svg" version="1.1">
                 <div class="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small">
-                    <apex:messages/>
+                    <apex:messages />
                 </div>
 
                 <apex:form id="SummitEventsRegisterAppointmentsForm" styleClass="slds-grid slds-wrap">

--- a/force-app/main/default/pages/SummitEventsRegisterAppointments.page
+++ b/force-app/main/default/pages/SummitEventsRegisterAppointments.page
@@ -16,6 +16,16 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/options.js')}" type="text/javascript"></script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(evtInstance.Instance_Title__c),' - ' + evtInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsRegisterGuests.page
+++ b/force-app/main/default/pages/SummitEventsRegisterGuests.page
@@ -18,6 +18,16 @@
             </script>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/guestRegistration.js')}" type="text/javascript"></script>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/sldsHelper.js')}" type="text/javascript"></script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsRegisterGuests.page
+++ b/force-app/main/default/pages/SummitEventsRegisterGuests.page
@@ -19,14 +19,15 @@
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/guestRegistration.js')}" type="text/javascript"></script>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/sldsHelper.js')}" type="text/javascript"></script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -16,6 +16,16 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
         <apex:define name="scriptsHead">
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/submit.js')}" type="text/javascript"></script>
+            <script>
+                dataLayer = [{
+                    'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
+                    'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
+                    'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
+                    'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
+                    'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
+                    'page': '{!$CurrentPage.Name}'
+                }];
+            </script>
         </apex:define>
         <apex:define name="sectionNav"/>
         <apex:define name="body">

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -121,13 +121,12 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <apex:repeat var="appointment" value="{!chosenAppointments}">
                                         <li>
                                             {!appointment.Appointment_Title__c}
-                                            <apex:outputPanel layout="none" rendered="{!!ISBLANK(appointment.Appointment_Type__c)}">
+                                            <apex:outputPanel layout="none" rendered="{!ISBLANK(appointment.Registrant_Input__c) && !ISBLANK(appointment.Appointment_Type__c)}">
                                                 <br/>{!appointment.Appointment_Type__c}
                                             </apex:outputPanel>
-                                            <apex:outputPanel layout="none" rendered="{!!ISBLANK(appointment.Description__c)}">
-                                                <br/>
-                                                {!appointment.Description__c}
-                                            </apex:outputPanel>
+                                            <!--<apex:outputPanel layout="none" rendered="{!!ISBLANK(appointment.Description__c)}">-->
+                                            <!--    <br/>{!appointment.Description__c}-->
+                                            <!--</apex:outputPanel>-->
                                             <apex:outputPanel layout="none" rendered="{!!ISBLANK(appointment.Registrant_Input__c)}">
                                                 <br/>{!appointment.Registrant_Input__c}
                                             </apex:outputPanel>

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -83,7 +83,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
                             <!-- Show Selected guest -->
                             <apex:outputPanel layout="none" rendered="{!IF(guestAnswers.size>0, true, false)}">
-                                <h2 class="slds-text-heading_medium slds-p-top_medium slds-p-bottom_medium slds-clearfix">Additional guest registered</h2>
+                                <h2 class="slds-text-heading_medium slds-p-top_medium slds-p-bottom_medium slds-clearfix">{!IF(ISBLANK(eventPage.Event_Guest_Submit_List_Label__c),'Additional guests registered', eventPage.Event_Guest_Submit_List_Label__c)}</h2>
                                 <apex:variable value="{!0}" var="guestNum"/>
                                 <apex:repeat var="guests" value="{!guestAnswers}">
                                     <article class="slds-card slds-clearfix slds-p-vertical_none">
@@ -105,7 +105,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
                             <!-- Show selected appointments -->
                             <apex:outputPanel layout="none" rendered="{!IF(chosenAppointments.size>0, true, false)}">
-                                <h2 class="slds-text-heading_medium slds-p-top_medium slds-p-bottom_medium slds-clearfix">Appointments</h2>
+                                <h2 class="slds-text-heading_medium slds-p-top_medium slds-p-bottom_medium slds-clearfix">{!IF(ISBLANK(eventPage.Event_Appointment_Submit_List_Label__c),'Selected options', eventPage.Event_Appointment_Submit_List_Label__c)}</h2>
                                 <ul id="chosenAppointments" class="slds-list_dotted">
                                     <apex:repeat var="appointment" value="{!chosenAppointments}">
                                         <li>

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -17,14 +17,15 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
             <link href="{!URLFOR($Resource.SummitEventsAssets, '/css/main.css')}" rel="stylesheet" type="text/css"/>
             <script src="{!URLFOR($Resource.SummitEventsAssets, '/js/submit.js')}" type="text/javascript"></script>
             <script>
-                dataLayer = [{
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({
                     'account': '{!IF(!ISBLANK(eventPage.Account__r.Name),eventPage.Account__r.Name, '')}',
                     'audience': '{!IF(!ISBLANK(eventPage.Audience__c),eventPage.Audience__c, '')}',
                     'eventLabel': '{!eventPage.Event_Name__c}{!IF(!ISBLANK(eventInstance.Instance_Title__c),' - ' + eventInstance.Instance_Title__c,'')}',
                     'category': '{!IF(!ISBLANK(eventPage.Filter_Category__c), eventPage.Filter_Category__c, '')}',
                     'sponsor': '{!IF(!ISBLANK(eventPage.Event_Sponsor__c), eventPage.Event_Sponsor__c, '')}',
                     'page': '{!$CurrentPage.Name}'
-                }];
+                });
             </script>
         </apex:define>
         <apex:define name="sectionNav"/>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1039,6 +1039,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events_Registration__c.BCC_Transactional_Email_Statuses__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.BCC_Transactional_Emails__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events_Registration__c.Campus_Tour_Location__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1159,6 +1159,16 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events_Registration__c.Event_Website_Referrer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.Event_Website__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events_Registration__c.Event__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1530,6 +1540,56 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Summit_Events_Registration__c.Virtual_Meeting_URL__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.gclid__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_campaign__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_content__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_creative_format__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_marketing_tactic__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_medium__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_source__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_source_platform__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_term__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -839,6 +839,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events_Question__c.Display_Style__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events_Question__c.Error_Assist_Text__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -1954,6 +1954,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Event_Appointment_Submit_List_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Event_Appointment_Title__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -2030,6 +2035,11 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Summit_Events__c.Event_Full_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Event_Guest_Submit_List_Label__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -906,6 +906,16 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.Event_Website_Referrer__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.Event_Website__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>false</editable>
         <field>Summit_Events_Registration__c.Event__c</field>
         <readable>true</readable>
@@ -1278,6 +1288,56 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Summit_Events_Registration__c.Virtual_Meeting_URL__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.gclid__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_campaign__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_content__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_creative_format__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_id__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_marketing_tactic__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_medium__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_source__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_source_platform__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events_Registration__c.utm_term__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -587,6 +587,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events_Question__c.Display_Style__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events_Question__c.Error_Assist_Text__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -786,6 +786,16 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events_Registration__c.BCC_Transactional_Email_Statuses__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events_Registration__c.BCC_Transactional_Emails__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
         <editable>true</editable>
         <field>Summit_Events_Registration__c.Campus_Tour_Location__c</field>
         <readable>true</readable>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1702,6 +1702,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Event_Appointment_Submit_List_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Event_Appointment_Title__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1778,6 +1783,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Summit_Events__c.Event_Full_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Event_Guest_Submit_List_Label__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
@@ -42,6 +42,7 @@ appointmentsReady(() => {
         title.innerHTML = title.innerHTML.replace(regExDouble, '\"');
     })
 
+    populateAppJSON();
 
     //Initiate add buttons in chooser column
     if (chooser) {

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
@@ -44,120 +44,121 @@ appointmentsReady(() => {
 
 
     //Initiate add buttons in chooser column
-    chooser.querySelectorAll(".appointmentAdd").forEach(function (appButton) {
-        appButton.addEventListener("click", (addAppointment) => {
-            addAppointment.preventDefault();
-            let appointment = appButton.closest(".appointment");
+    if (chooser) {
+        chooser.querySelectorAll(".appointmentAdd").forEach(function (appButton) {
+            appButton.addEventListener("click", (addAppointment) => {
+                addAppointment.preventDefault();
+                let appointment = appButton.closest(".appointment");
 
-            //check for required fields
-            let error = false;
-            let requiredInputs = appointment.querySelectorAll('.slds-is-required');
-            requiredInputs.forEach(function (reqs) {
-                let reqApp = reqs.closest(".appointment");
-                let incomingValue = '';
-                //Check for select input first
-                if (reqApp.querySelector("select")) {
-                    let selType = appointment.querySelector("select");
-                    incomingValue = selType.value;
-                } else if (reqApp.querySelector(".appointmentCustomInput")) {
-                    let inputType = appointment.querySelector(".appointmentCustomInput");
-                    incomingValue = inputType.value;
-                }
-                incomingValue = incomingValue.trim();
-                if (!incomingValue) {
-                    reqApp.classList.add('slds-has-error');
-                    error = true;
+                //check for required fields
+                let error = false;
+                let requiredInputs = appointment.querySelectorAll('.slds-is-required');
+                requiredInputs.forEach(function (reqs) {
+                    let reqApp = reqs.closest(".appointment");
+                    let incomingValue = '';
+                    //Check for select input first
+                    if (reqApp.querySelector("select")) {
+                        let selType = appointment.querySelector("select");
+                        incomingValue = selType.value;
+                    } else if (reqApp.querySelector(".appointmentCustomInput")) {
+                        let inputType = appointment.querySelector(".appointmentCustomInput");
+                        incomingValue = inputType.value;
+                    }
+                    incomingValue = incomingValue.trim();
+                    if (!incomingValue) {
+                        reqApp.classList.add('slds-has-error');
+                        error = true;
+                    }
+                });
+
+                if (!error) {
+                    //move and adjust data
+                    let chosenArea = document.getElementById("chosen");
+
+                    let limit = appointment.dataset.limit;
+
+                    addAppointment = document.createElement('div');
+                    addAppointment.classList.add('slds-box', 'slds-box_small', 'slds-m-vertical_x-small', 'appointmentChosen');
+                    Object.assign(addAppointment.dataset, appointment.dataset);
+                    addAppointment.classList.add('appointmentTitle', 'slds-text-body', 'slds-m-vertical_small');
+
+                    let appTitle = document.createElement('div');
+                    appTitle.classList.add('slds-text-heading_small', 'slds-p-bottom_x-small');
+                    let findTitle = appointment.querySelector(".appointmentTitle");
+                    appTitle.textContent = findTitle.textContent;
+                    addAppointment.append(appTitle);
+
+                    let findDescription = appointment.querySelector('.appointmentDesc');
+                    if (findDescription !== null) {
+                        let appDescription = document.createElement('div');
+                        appDescription.classList.add('slds-text-body_regular');
+                        appDescription.textContent = findDescription.textContent;
+                        addAppointment.append(appDescription);
+                    }
+
+                    let registrantInput = '';
+                    if (appointment.querySelector(".appointmentType")) {
+                        let selType = appointment.querySelector(".appointmentType");
+                        registrantInput += selType.options[selType.selectedIndex].value;
+                    }
+
+                    if (appointment.querySelector(".appointmentCustomInput")) {
+                        let inputType = appointment.querySelector(".appointmentCustomInput");
+                        registrantInput += inputType.value;
+                    }
+
+                    if (registrantInput) {
+                        registrantInput = registrantInput.replace(regExDouble, '\"').replace(regExSingle, '\'');
+                        let appDesc = document.createElement('div');
+                        appDesc.classList.add('appointmentDesc', 'slds-text-body_regular', 'slds-p-top_x-small');
+                        appDesc.textContent = registrantInput;
+                        addAppointment.append(appDesc);
+                    }
+
+                    addAppointment.dataset.appinput = registrantInput;
+
+                    //Create the remove button
+                    let removeButton = document.createElement('a');
+                    removeButton.classList.add('appointmentRemove', 'slds-button', 'slds-button_neutral', 'slds-m-top_small');
+                    removeButton.textContent = ' Remove ';
+                    removeButton.addEventListener("click", function (evt) {
+                        evt.preventDefault();
+                        removeSelectedOption(removeButton)
+                    });
+                    addAppointment.appendChild(removeButton);
+
+                    addAppointment.id = 'app' + limit + '-' + appointment.id;
+                    appointment.dataset.limit = String(limit - 1);
+
+                    chosenArea.append(addAppointment);
+
+                    //remove all values from hidden appointments.
+                    if (appointment.classList.contains('slds-has-error')) {
+                        appointment.classList.remove('slds-has-error');
+                    }
+
+                    if (appointment.classList.contains('appointment-has-error')) {
+                        appointment.classList.remove('appointment-has-error');
+                    }
+
+                    if (appointment.querySelector(".appointmentType")) {
+                        let selType = appointment.querySelector(".appointmentType");
+                        registrantInput += selType.options[selType.selectedIndex].value = '';
+                    }
+
+                    if (appointment.querySelector(".appointmentCustomInput")) {
+                        let inputType = appointment.querySelector(".appointmentCustomInput");
+                        registrantInput += inputType.value + '';
+                    }
+
+                    if (appointment.dataset.limit < 1) {
+                        appointment.style.display = "none";
+                    }
+
                 }
             });
-
-            if (!error) {
-                //move and adjust data
-                let chosenArea = document.getElementById("chosen");
-
-                let limit = appointment.dataset.limit;
-
-                addAppointment = document.createElement('div');
-                addAppointment.classList.add('slds-box', 'slds-box_small', 'slds-m-vertical_x-small', 'appointmentChosen');
-                Object.assign(addAppointment.dataset, appointment.dataset);
-                addAppointment.classList.add('appointmentTitle', 'slds-text-body', 'slds-m-vertical_small');
-
-                let appTitle = document.createElement('div');
-                appTitle.classList.add('slds-text-heading_small', 'slds-p-bottom_x-small');
-                let findTitle = appointment.querySelector(".appointmentTitle");
-                appTitle.textContent = findTitle.textContent;
-                addAppointment.append(appTitle);
-
-                let findDescription = appointment.querySelector('.appointmentDesc');
-                if (findDescription !== null) {
-                    let appDescription = document.createElement('div');
-                    appDescription.classList.add('slds-text-body_regular');
-                    appDescription.textContent = findDescription.textContent;
-                    addAppointment.append(appDescription);
-                }
-
-                let registrantInput = '';
-                if (appointment.querySelector(".appointmentType")) {
-                    let selType = appointment.querySelector(".appointmentType");
-                    registrantInput += selType.options[selType.selectedIndex].value;
-                }
-
-                if (appointment.querySelector(".appointmentCustomInput")) {
-                    let inputType = appointment.querySelector(".appointmentCustomInput");
-                    registrantInput += inputType.value;
-                }
-
-                if (registrantInput) {
-                    registrantInput = registrantInput.replace(regExDouble, '\"').replace(regExSingle, '\'');
-                    let appDesc = document.createElement('div');
-                    appDesc.classList.add('appointmentDesc', 'slds-text-body_regular', 'slds-p-top_x-small');
-                    appDesc.textContent = registrantInput;
-                    addAppointment.append(appDesc);
-                }
-
-                addAppointment.dataset.appinput = registrantInput;
-
-                //Create the remove button
-                let removeButton = document.createElement('a');
-                removeButton.classList.add('appointmentRemove', 'slds-button', 'slds-button_neutral', 'slds-m-top_small');
-                removeButton.textContent = ' Remove ';
-                removeButton.addEventListener("click", function (evt) {
-                    evt.preventDefault();
-                    removeSelectedOption(removeButton)
-                });
-                addAppointment.appendChild(removeButton);
-
-                addAppointment.id = 'app' + limit + '-' + appointment.id;
-                appointment.dataset.limit = String(limit - 1);
-
-                chosenArea.append(addAppointment);
-
-                //remove all values from hidden appointments.
-                if (appointment.classList.contains('slds-has-error')) {
-                    appointment.classList.remove('slds-has-error');
-                }
-
-                if (appointment.classList.contains('appointment-has-error')) {
-                    appointment.classList.remove('appointment-has-error');
-                }
-
-                if (appointment.querySelector(".appointmentType")) {
-                    let selType = appointment.querySelector(".appointmentType");
-                    registrantInput += selType.options[selType.selectedIndex].value = '';
-                }
-
-                if (appointment.querySelector(".appointmentCustomInput")) {
-                    let inputType = appointment.querySelector(".appointmentCustomInput");
-                    registrantInput += inputType.value + '';
-                }
-
-                if (appointment.dataset.limit < 1) {
-                    appointment.style.display = "none";
-                }
-
-            }
         });
-    });
-
+    }
 });
 
 function removeSelectedOption(removeButton) {
@@ -197,17 +198,19 @@ function populateAppJSON() {
 
 function checkForRequiredAppointments() {
     let chooser = document.getElementById('chooser');
-    let requiredAppointments = chooser.querySelectorAll('.appointmentRequired');
     let allAppGood = true;
-    requiredAppointments.forEach(function (app) {
-        if (window.getComputedStyle(app).display !== "none") {
-            allAppGood = false;
-            app.classList.add('appointment-has-error');
-            if (!app.classList.contains('slds-is-open')) {
-                app.classList.add('slds-is-open');
+    if (chooser) {
+        let requiredAppointments = chooser.querySelectorAll('.appointmentRequired');
+        requiredAppointments.forEach(function (app) {
+            if (window.getComputedStyle(app).display !== "none") {
+                allAppGood = false;
+                app.classList.add('appointment-has-error');
+                if (!app.classList.contains('slds-is-open')) {
+                    app.classList.add('slds-is-open');
+                }
+                fadein();
             }
-            fadein();
-        }
-    });
+        });
+    }
     return allAppGood;
 }

--- a/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
@@ -100,7 +100,7 @@ private class SummitEventsConfirmation_TEST {
                             Summit_Events_Registration__c
                     WHERE Id = :seaTestRegistration.Id
             ];
-            System.assertEquals(checkRegistrationStatus.Status__c, 'Started');
+            System.assertEquals(checkRegistrationStatus.Status__c, 'Registered');
             Test.stopTest();
         }
     }

--- a/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
@@ -62,7 +62,7 @@ private class SummitEventsConfirmation_TEST {
         System.runAs(testUser) {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsConfirmation;
-            pageRef.getParameters().put('adminopen', 'true');
+            pageRef.getParameters().put('adminopen', '1');
             Test.setCurrentPage(pageRef);
             SummitEventsShared SEShared = new SummitEventsShared();
             SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
@@ -204,7 +204,7 @@ private class SummitEventsConfirmation_TEST {
         insert testFees;
 
         System.runAs(testUser) {
-            Test.startTest();
+
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
@@ -221,11 +221,8 @@ private class SummitEventsConfirmation_TEST {
                     pageMessages.add(message.getSummary());
                 }
             }
-
+            Test.startTest();
             System.assert(confirmCtrl.paymentReceived);
-
-            confirmCtrl.checkEventDetails();
-
             Summit_Events_Registration__c checkRegistrationStatus = [
                     SELECT Id, Status__c
                     FROM

--- a/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
@@ -224,6 +224,8 @@ private class SummitEventsConfirmation_TEST {
 
             System.assert(confirmCtrl.paymentReceived);
 
+            confirmCtrl.checkEventDetails();
+
             Summit_Events_Registration__c checkRegistrationStatus = [
                     SELECT Id, Status__c
                     FROM

--- a/force-app/test/default/classes/SummitEventsRegister_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegister_TEST.cls
@@ -71,6 +71,46 @@ private class SummitEventsRegister_TEST {
             Test.stopTest();
         }
     }
+    @IsTest static void testEventWithUTMParameters() {
+        List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
+        Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'Test', 'Tester', 'test@test.net', '55555', '1971-03-22', '2012', null);
+        Summit_Events__c seaTestEvent = SummitEventsTestSharedDataFactory.getEventRecord(seaTestInstances[1].Event__c);
+        User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User','Summit_Events_Registrant');
+        System.runAs(testUser) {
+
+            PageReference pageRef = Page.SummitEventsRegister;
+            Test.setCurrentPage(pageRef);
+            ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances[1].Id);
+            ApexPages.currentPage().getParameters().put('audience', 'Transfer');
+            List<String> analyticCodes = new List<String>{
+                    'gclid__c', 'utm_campaign__c', 'utm_content__c', 'utm_creative_format__c', 'utm_id__c',
+                    'utm_marketing_tactic__c', 'utm_medium__c', 'utm_source__c', 'utm_source_platform__c', 'utm_term__c'
+            };
+            for (String code : analyticCodes) {
+                String urlParameter = code.removeEnd('__c');
+                ApexPages.currentPage().getParameters().put(urlParameter, urlParameter + '_TEST');
+            }
+            SummitEventsRegisterController registerController = new SummitEventsRegisterController();
+            registerController.eventRegistration.Registrant_First_Name__c = 'Test';
+            registerController.eventRegistration.Registrant_Last_Name__c = 'Tester';
+            registerController.eventRegistration.Registrant_Email__c = 'test@test.net';
+            registerController.saveContactRegistration();
+            Summit_Events_Registration__c registration = [
+                    SELECT Id, Name, Registrant_First_Name__c, Registrant_Last_Name__c, Registrant_Email__c,
+                            utm_term__c, gclid__c, utm_campaign__c, utm_content__c, utm_creative_format__c, utm_id__c,
+                            utm_marketing_tactic__c, utm_medium__c, utm_source_platform__c, utm_source__c
+                    FROM Summit_Events_Registration__c
+                    WHERE id = :registerController.eventRegistration.Id
+            ];
+            Test.startTest();
+            for (String code : analyticCodes) {
+                String urlParameter = code.removeEnd('__c');
+                System.assertEquals(registration.get(code), urlParameter + '_TEST');
+            }
+            Test.stopTest();
+        }
+    }
+
 
     @IsTest static void testEventWithAppointments() {
         List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();


### PR DESCRIPTION
# Critical Changes

# Changes
- Added two data fields to event data returned by REST API: title_event__c, title_instance__c. This splits out the combine title in title to be used easily separated.
-  When a user is logged in to a community and a contact record is found the registration is pre-filled with the contact information. This information was locked to the user then. If the field was empty the user could not progress because the field was locked and validation would not allow any fields to be empty. This bug is fixed.
- When a user is logged in to a community the contact record is automatically connected to the registration. previously this was not happening.
- Appointments that are not shown, but set to auto confirm, will now auto confirm if the appointment page is skipped. Auto building and time are also corrected in this scenario.
- A data layer for google tag manager has been added to pages with account name, audience, event label, category, and sponsor.
- BCC email and status setting are now active on registration.
- utm tracking codes are recorded on registration.
- Custom questions now have a display option to show the question full width, half width and third width. On mobile all fields are full width. This defaults to half width.
- Admin open registration link bug fixed.
- Ask phone now has Ask mobile and Ask mobile and require. Mobile is stripped off the front of the label for this option and text message questions appear.
- Appointment Types with only one item in them for a picklist now appear without erroring.
- Appointment Category and Type can be set on an Appointment Type record and these will be added to the appointment record without asking the registrant for a selection.
- Appointment Type is now recorded on the appointment when set.
- Label fields have been added for the submit page for titles above appointment lists and guest lists.
- When transactional emails are used and fail they fail gracefully now so that registration is not interrupted. This failure is recorded on the activity record. Emails can fail if you reach your org daily limit of 5000 emails (or 15 in scratch orgs).
- Calculations for event closure utilize the Instance Close Date and Time for event closure better. Also system time is set to the time zone of the instance for event relative time comparison. 

# Issues Closed
- Closes #482 
- Closes #480
- Closes #479 
- Closes #476 
- Closes #474 
- Closes #473 
- Closes #472 
- Closes #469 
- Closes #468 
- Closes #467 
- Closes #464 
- Closes #395
- Closes #484 
