### PR TITLE
Aug23 fixes

### DIFF
--- a/force-app/main/default/applications/Summit_Events_Lightning.app-meta.xml
+++ b/force-app/main/default/applications/Summit_Events_Lightning.app-meta.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomApplication xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionOverrides>
+        <actionName>View</actionName>
+        <comment>Action override created by Lightning App Builder during activation.</comment>
+        <content>Summit_Events_Record_Page</content>
+        <formFactor>Large</formFactor>
+        <skipRecordTypeSelect>false</skipRecordTypeSelect>
+        <type>Flexipage</type>
+        <pageOrSobjectType>Summit_Events__c</pageOrSobjectType>
+    </actionOverrides>
     <brand>
         <headerColor>#903F98</headerColor>
         <logo>summit_events_logo128x128</logo>

--- a/force-app/main/default/classes/SummitEventsAddToCalendarController.cls
+++ b/force-app/main/default/classes/SummitEventsAddToCalendarController.cls
@@ -5,7 +5,6 @@
 
 public with sharing class SummitEventsAddToCalendarController {
 
-    public SummitEventsShared SEShared = new SummitEventsShared();
     public String DTStart { get; set; }
     public String TIMEZONE2 { get; set; }
     public String DTEnd { get; set; }
@@ -36,9 +35,9 @@ public with sharing class SummitEventsAddToCalendarController {
             Summit_Events_Instance__c eventInformation = getEventInformation(URLInstanceID);
 
             if (eventInformation != null) {
-                DTStart = SEShared.convertDateToDatetime(eventInformation.Instance_Start_Date__c, eventInformation.Instance_Start_Time__c, eventInformation.Instance_Time_Zone__c).format('yyyyMMdd\'T\'HHmmss\'Z\'');
-                DTEnd = SEShared.convertDateToDatetime(eventInformation.Instance_End_Date__c, eventInformation.Instance_End_Time__c, eventInformation.Instance_Time_Zone__c).format('yyyyMMdd\'T\'HHmmss\'Z\'');
-                TIMEZONE2 = SEShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
+                DTStart = SummitEventsShared.convertDateToDatetime(eventInformation.Instance_Start_Date__c, eventInformation.Instance_Start_Time__c, eventInformation.Instance_Time_Zone__c).format('yyyyMMdd\'T\'HHmmss\'Z\'');
+                DTEnd = SummitEventsShared.convertDateToDatetime(eventInformation.Instance_End_Date__c, eventInformation.Instance_End_Time__c, eventInformation.Instance_Time_Zone__c).format('yyyyMMdd\'T\'HHmmss\'Z\'');
+                TIMEZONE2 = SummitEventsShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
 
                 VTIMEZONE = getDayLightSavings(TIMEZONE2, eventInformation.Instance_Start_Date__c.year(), eventInformation.Instance_End_Date__c.year());
 
@@ -230,7 +229,7 @@ public with sharing class SummitEventsAddToCalendarController {
                     urlCalendarLink += '/';
                     urlCalendarLink += formattedGmtVersionOfDate(eventInformation.Instance_End_Date__c, eventInformation.Instance_End_Time__c);
                     //Timezone ctz=America/New_York
-                    urlCalendarLink += '&ctz=' + SEShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
+                    urlCalendarLink += '&ctz=' + SummitEventsShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
                     //Location - Google readable address
                     urlCalendarLink += '&location=' + EncodingUtil.urlEncode(getEventAddress(eventInformation), 'UTF-8');
                     //Url of source of the event
@@ -257,7 +256,7 @@ public with sharing class SummitEventsAddToCalendarController {
                     //Street address
                     urlCalendarLink += '&in_st=' + EncodingUtil.urlEncode(getEventAddress(eventInformation), 'UTF-8');
                     //City/State/Zip = Atlanta, GA, 30307
-                    urlCalendarLink += '&in_csz=' + SEShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
+                    urlCalendarLink += '&in_csz=' + SummitEventsShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
                     //Unique Id
                     //urlCalendarLink += '&uid=' + NewGuid();
                     linkPage = new PageReference(urlCalendarLink);
@@ -276,7 +275,7 @@ public with sharing class SummitEventsAddToCalendarController {
                     urlCalendarLink += '&location=' + EncodingUtil.urlEncode(getLocationTitle(eventInformation) + ',  ' + getEventAddress(eventInformation), 'UTF-8');
 
                     //Start date in zurich gmt time (YYYY-MM-DDTHH:mm:SSZ) or date (YYYY-MM-DD, for all-day events)
-                    String timezoneString = SEShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
+                    String timezoneString = SummitEventsShared.getTimeZonePick(eventInformation.Instance_Time_Zone__c);
                     TimeZone tz = TimeZone.getTimeZone(timezoneString);
                     Date startD = eventInformation.Instance_Start_Date__c;
                     Time startT = eventInformation.Instance_Start_Time__c;

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -5,12 +5,11 @@
 
 public with sharing class SummitEventsAdditionalQuestionsCtlr {
 
-    final SummitEventsShared SeaShared = new SummitEventsShared();
     public String templateSelected { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public Summit_Events_Instance__c eventInstance { get; set; }
     public Summit_Events_Registration__c eventRegistration { get; set; }
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public String instanceName { get; set; }
     public String startTimeString { get; set; }
     public String endTimeString { get; set; }
@@ -56,7 +55,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
 
     public SummitEventsAdditionalQuestionsCtlr() {
         eventIsClosed = false;
-        eventInformation = SeaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
         questionWrapper = new List<questionItem>();
         Map<String, String> hiddenValues = new Map<String, String>();
 
@@ -84,14 +83,14 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     WITH SECURITY_ENFORCED
             ];
 
-            templateSelected = SeaShared.getTemplate(eventPage.Template__c);
-            pageFlow = SeaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
-            formattedNavDate = SeaShared.navBreadcrumbBuilder(eventInstance);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
+            pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
+            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
             instanceName = eventInstance.Name;
-            startTimeString = SeaShared.formatTime(eventInstance.Instance_Start_Time__c, false);
-            endTimeString = SeaShared.formatTime(eventInstance.Instance_End_Time__c, false);
+            startTimeString = SummitEventsShared.formatTime(eventInstance.Instance_Start_Time__c, false);
+            endTimeString = SummitEventsShared.formatTime(eventInstance.Instance_End_Time__c, false);
 
-            eventIsClosed = SeaShared.isEventClosed(eventInstance);
+            eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
             //Get the question object questions
             additionalQuestions = [
@@ -151,7 +150,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     } else {
                         //Check if map to field exists
                         mapToField = question.Map_to_Field__c.trim().toLowerCase();
-                        quest.setupError = SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, '', true, 'Map to field: ');
+                        quest.setupError = SummitEventsShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, '', true, 'Map to field: ');
                     }
 
                     //It would be counter productive to map to the same field, but if you do it live with the ordering consequences with your questions
@@ -164,7 +163,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     //build wrapper class to type and make picklist lists
                     quest.question = question.Question_Label__c;
                     quest.required = question.Required__c;
-                    quest.questionId = SeaShared.encryptString(question.Id);
+                    quest.questionId = SummitEventsShared.encryptString(question.Id);
                     quest.type = question.Question_Field_Type__c;
 
                     if (String.isNotBlank(question.Existing_Picklist_Values__c)) {
@@ -185,7 +184,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                             existingPickListField = namespace + existingPickListField;
                         }
                         //Test if picklist is accessible and is a picklist
-                        quest.setupError += SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', existingPickListField, 'picklist', false, '');
+                        quest.setupError += SummitEventsShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', existingPickListField, 'picklist', false, '');
                         if (String.isBlank(quest.setupError)) {
                             quest.picklist = createExistingPicklist(existingPickListField);
                         }
@@ -237,10 +236,10 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                         lookupObject = '';
                         if (String.isNotBlank(question.Lookup_Object__c)) {
                             lookupObject = question.Lookup_Object__c.trim().toLowerCase();
-                            quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, '', '', false, 'Lookup Object: ');
+                            quest.setupError += SummitEventsShared.checkFieldGuestAccess(lookupObject, '', '', false, 'Lookup Object: ');
                         }
 
-                        quest.setupError += SeaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, 'reference', true, 'Map To Field: ');
+                        quest.setupError += SummitEventsShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', mapToField, 'reference', true, 'Map To Field: ');
 
                         if (String.isNotBlank(question.Lookup_Fields__c)) {
                             String questionLookupFields = question.Lookup_Fields__c.toLowerCase();
@@ -253,7 +252,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                             for (String lookUpField : lookupFields) {
                                 lookUpField = lookUpField.trim();
 
-                                quest.setupError += SeaShared.checkFieldGuestAccess(lookupObject, lookUpField, '', false, 'Look up field: ');
+                                quest.setupError += SummitEventsShared.checkFieldGuestAccess(lookupObject, lookUpField, '', false, 'Look up field: ');
                                 if (String.isBlank(quest.setupError)) {
                                     cleanLookUpFields.add(lookUpField);
                                     if (mapToFieldIsLookup) {
@@ -281,7 +280,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
 
                         if (question.Question_Field_Type__c.equalsIgnoreCase('lookup')) {
                             //serialize object with query info in it to retrieve later when decrypted
-                            quest.lookup = SeaShared.encryptString(JSON.serialize(queryInfo));
+                            quest.lookup = SummitEventsShared.encryptString(JSON.serialize(queryInfo));
 
                             List<String> lookupFieldsRelation = new List<String>();
                             if (String.isNotBlank(question.Lookup_Fields__c)) {
@@ -450,7 +449,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
     }
 
     public PageReference checkEventDetails() {
-        return SeaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
 
@@ -459,7 +458,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
         SummitEventsShared SeaShared = new SummitEventsShared();
         List<queryReturn> returnValues = new List<queryReturn>();
         if (String.isNotBlank(question) && String.isNotBlank(term)) {
-            question = SeaShared.decryptString(question, true);
+            question = SummitEventsShared.decryptString(question, true);
             Map<String, String> queryInfo = (Map<String, String>) JSON.deserialize(question, Map<String, String>.class);
             if (queryInfo.size() > 0) {
                 String lookupQuery = '';

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -455,7 +455,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
 
     @RemoteAction
     public static List<queryReturn> lookupSearch(String question, String term) {
-        SummitEventsShared SeaShared = new SummitEventsShared();
+
         List<queryReturn> returnValues = new List<queryReturn>();
         if (String.isNotBlank(question) && String.isNotBlank(term)) {
             question = SummitEventsShared.decryptString(question, true);

--- a/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsAdditionalQuestionsCtlr.cls
@@ -97,7 +97,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                     SELECT Name, Question_Label__c, Question_Field_Type__c, Default_Value__c, Registrant_Type__c, Instructions__c, Help_Text__c, Display_Order__c,
                             Map_to_Field__c, Picklist_Values__c, Text_Limit__c, Controlling_Question__c, Controlling_Logic__c, Required__c, Is_Visible__c, Error_Assist_Text__c,
                             Lookup_Object__c, Lookup_Fields__c, Lookup_Where_Clause__c, Lookup_No_Results_Label__c, Lookup_Secondary_Input_Link_Text__c, Lookup_Secondary_Value_Field__c,
-                            Lookup_Secondary_Input_Instructions__c, Lookup_Results_Icon__c, Existing_Picklist_Values__c, Display_Style__c
+                            Lookup_Secondary_Input_Instructions__c, Lookup_Results_Icon__c, Existing_Picklist_Values__c, Display_Style__c, Picklist_Values_Long__c
                     FROM Summit_Events_Question__c
                     WHERE Event__c = :eventInformation.eventId
                     AND (Registrant_Type__c = 'Registrant' OR Registrant_Type__c = 'Registrant and Guest')
@@ -189,7 +189,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
                             quest.picklist = createExistingPicklist(existingPickListField);
                         }
                     } else {
-                        quest.picklist = createPicklists(question.Picklist_Values__c);
+                        quest.picklist = SummitEventsShared.createPicklistsFromStrings(question.Picklist_Values__c, question.Picklist_Values_Long__c);
                     }
 
                     quest.help = question.Help_Text__c;
@@ -449,7 +449,7 @@ public with sharing class SummitEventsAdditionalQuestionsCtlr {
     }
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('question');
     }
 
 

--- a/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
+++ b/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
@@ -67,7 +67,6 @@ public with sharing class SummitEventsAppointmentTriggerHandler {
 
             if (allAppointments.size() > 0) {
 
-                SummitEventsShared seaShared = new SummitEventsShared();
                 Map<Id, List<Summit_Events_Appointments__c>> appointmentListByRegistration = new Map<Id, List<Summit_Events_Appointments__c>>();
                 //Get event itinerary generating parameters
                 Set<Id> eventIds = new Set<Id>();
@@ -170,10 +169,10 @@ public with sharing class SummitEventsAppointmentTriggerHandler {
                             currentRegAppointment += '<b>' + apt.Appointment_Title__c.trim() + '</b><br/>';
                         }
                         if (String.isNotBlank(apt.Description__c)) {
-                            currentRegAppointment += seaShared.removeHTMLandEscape(apt.Description__c, false).trim() + '<br/>';
+                            currentRegAppointment += SummitEventsShared.removeHTMLandEscape(apt.Description__c, false).trim() + '<br/>';
                         }
                         if (String.isNotBlank(apt.Registrant_Input__c)) {
-                            currentRegAppointment += seaShared.removeHTMLandEscape(apt.Registrant_Input__c, false).trim() + '<br/>';
+                            currentRegAppointment += SummitEventsShared.removeHTMLandEscape(apt.Registrant_Input__c, false).trim() + '<br/>';
                         }
                         if (String.isNotBlank(currentRegAppointment)) {
                             requestedAppointments += currentRegAppointment + '<br/>';

--- a/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
+++ b/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
@@ -219,7 +219,6 @@ public with sharing class SummitEventsAppointmentTriggerHandler {
         for (String appointmentField : appointmentObjectFields) {
             appointmentObjectFieldsLowercase.add(appointmentField.toLowerCase());
         }
-        System.debug(appointmentObjectFields);
 
         //Keep track of already added fields so as not to corrupt the query with a duplicate
         Set<String> fieldsFound = new Set<String>();

--- a/force-app/main/default/classes/SummitEventsCancelReviewController.cls
+++ b/force-app/main/default/classes/SummitEventsCancelReviewController.cls
@@ -48,8 +48,6 @@ public with sharing class SummitEventsCancelReviewController {
 
                         templateSelected = SummitEventsShared.getTemplate(eventRegistration.Event__r.Template__c);
 
-                        SummitEventsShared SEShared = new SummitEventsShared();
-
                         appointments = [
                                 SELECT Id, Appointment_Title__c, Appointment_Category__c, Appointment_Type__c
                                 FROM Summit_Events_Appointments__c

--- a/force-app/main/default/classes/SummitEventsCancelReviewController.cls
+++ b/force-app/main/default/classes/SummitEventsCancelReviewController.cls
@@ -4,9 +4,8 @@
 // Created by Thaddaeus Dahlberg on  5/1/2018.
 
 public with sharing class SummitEventsCancelReviewController {
-    public SummitEventsShared SEShared = new SummitEventsShared();
     public Summit_Events_Registration__c eventRegistration { get; set; }
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public List<Summit_Events_Appointments__c> appointments { get; set; }
     public String templateSelected { get; set; }
     public Boolean eventOver { get; set; }
@@ -21,10 +20,10 @@ public with sharing class SummitEventsCancelReviewController {
         eventOver = false;
 
         if (!String.isBlank(eventParameter)) {
-            String decryptedParameter = SEShared.decryptString(eventParameter, false);
+            String decryptedParameter = SummitEventsShared.decryptString(eventParameter, false);
             if (String.isNotBlank(decryptedParameter)) {
                 try {
-                    eventInformation = (SummitEventsShared.SummitEventsInfo) JSON.deserialize(decryptedParameter, SummitEventsShared.SummitEventsInfo.class);
+                    eventInformation = (SummitEventsInfo) JSON.deserialize(decryptedParameter, SummitEventsInfo.class);
                 } catch (Exception e) {
                     System.debug(e.getMessage());
                 }
@@ -47,7 +46,7 @@ public with sharing class SummitEventsCancelReviewController {
 
                     if (eventRegistration != null) {
 
-                        templateSelected = SEShared.getTemplate(eventRegistration.Event__r.Template__c);
+                        templateSelected = SummitEventsShared.getTemplate(eventRegistration.Event__r.Template__c);
 
                         SummitEventsShared SEShared = new SummitEventsShared();
 
@@ -66,12 +65,12 @@ public with sharing class SummitEventsCancelReviewController {
                                 WITH SECURITY_ENFORCED
                         ];
 
-                        if (SEShared.convertDateToDatetime(eventRegistration.Event_Instance__r.Instance_End_Date__c, null, '') < SEShared.adjustForTimeZone(Datetime.now(), eventRegistration.Event_Instance__r.Instance_Time_Zone__c)) {
+                        if (SummitEventsShared.convertDateToDatetime(eventRegistration.Event_Instance__r.Instance_End_Date__c, null, '') < SummitEventsShared.adjustForTimeZone(Datetime.now(), eventRegistration.Event_Instance__r.Instance_Time_Zone__c)) {
                             eventOver = true;
                         }
 
                         if (eventInstance != null) {
-                            formattedNavDate = SEShared.navBreadcrumbBuilder(eventInstance);
+                            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
                         }
                         eventNotFound = false;
                     }

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -40,7 +40,7 @@ public with sharing class SummitEventsConfirmationController {
                             Event_Home_Link_Title__c, Event_Home_Link_URL__c, Tracking_Confirmation_Registration__c, Event_Full_Text__c,
                             Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Hand_Raise_Action__c, Account__r.Name, Audience__c,
                             Filter_Category__c, Event_Sponsor__c, Event_Fee_Label__c, Event_Fee_Submit_List_Label__c, Event_Fee_Total_Label__c,
-                            Event_Fee__c, Event_Fee_Allocation__c, Event_Fee_Additional__c
+                            Event_Fee__c, Event_Fee_Allocation__c, Event_Fee_Additional__c, Event_Fees_Received_Label__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED
@@ -265,15 +265,15 @@ public with sharing class SummitEventsConfirmationController {
                 WITH SECURITY_ENFORCED
         ];
 
-        Integer payments = [
-                SELECT COUNT()
+        List<Summit_Events_Payment__c> payments = [
+                SELECT Id, Payment_Amount__c
                 FROM Summit_Events_Payment__c
                 WHERE Event_Registration__c = :eventInformation.registrationId
         ];
 
         String errorMessage = '';
 
-        if (payments == 1) {
+        if (payments.size() > 0) {
             paymentReceived = true;
             //Payment received. Get payment fees to display.
             feesByIndex = new Map<String, String>();
@@ -288,13 +288,13 @@ public with sharing class SummitEventsConfirmationController {
                 }
 
             }
-            if (existingPaymentAmount > 0) {
-                totalPaymentAmount = totalPaymentAmount - existingPaymentAmount;
-            }
+            existingPaymentAmount = payments[0].Payment_Amount__c;
+            totalPaymentAmount = totalPaymentAmount - payments[0].Payment_Amount__c;
             if (totalPaymentAmount > 0) {
                 hasFees = true;
             }
-        } else if (payments == 0) {
+
+        } else if (payments.size() == 0) {
             errorMessage = 'Payment was not received. Please try again.';
         } else {
             errorMessage = 'Multiple payments were received. Please contact event.';

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -227,7 +227,6 @@ public with sharing class SummitEventsConfirmationController {
                         //Build encrypted string for registration. Used for cancel link or other services outside of Summit Events App
                         //valid = false will not work for registration pages, only confirmation and cancel registration pages
 
-                        System.debug(eventInformation.registrationId);
                         String encryptedString = SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, eventInformation.registrationId, false);
 
                         if (encryptedString.length() > 255) {

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -4,8 +4,7 @@
 // Created by Thaddaeus Dahlberg on 5/1/2018.
 
 public with sharing class SummitEventsConfirmationController {
-    public SummitEventsShared seaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public Summit_Events_Instance__c eventInstance { get; set; }
     public String templateSelected { get; set; }
@@ -33,7 +32,7 @@ public with sharing class SummitEventsConfirmationController {
 
     public SummitEventsConfirmationController() {
         eventIsClosed = false;
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
 
         if (!String.isEmpty(eventInformation.eventId)) {
             eventPage = [
@@ -49,7 +48,7 @@ public with sharing class SummitEventsConfirmationController {
 
             if (eventPage != null) {
 
-                templateSelected = seaShared.getTemplate(eventPage.Template__c);
+                templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
                 if (String.isNotBlank(eventInformation.instanceId)) {
                     eventInstance = [
@@ -60,9 +59,9 @@ public with sharing class SummitEventsConfirmationController {
                             LIMIT 1
                     ];
 
-                    eventIsClosed = seaShared.isEventClosed(eventInstance);
+                    eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
-                    formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
+                    formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
                 }
 
                 if (String.isNotBlank(eventInformation.registrationId)) {
@@ -83,11 +82,11 @@ public with sharing class SummitEventsConfirmationController {
     public PageReference checkEventDetails() {
 
         PageReference pageRef = null;
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
         Boolean eventRegistrationSuccess = true;
 
         //Make sure the event has not expired
-        eventIsClosed = seaShared.isEventClosed(eventInstance);
+        eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
         // Default to submit page, submit will redirect to beginning if no reg id is present. Prevents pre-filled forms in one step registrations.
         ApexPages.currentPage().getHeaders().put('referer', Page.SummitEventsSubmit.getUrl());
@@ -131,7 +130,7 @@ public with sharing class SummitEventsConfirmationController {
                             for (Question q : guestAnswers[xx].questions) {
                                 Id questionId = null;
                                 try {
-                                    questionId = seaShared.decryptString(q.id, true);
+                                    questionId = SummitEventsShared.decryptString(q.id, true);
                                 } catch (Exception e) {
                                     ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'Invalid question Id detected.'));
                                 }
@@ -229,7 +228,7 @@ public with sharing class SummitEventsConfirmationController {
 
                     if (eventRegistrationSuccess && pageRef == null) {
                         //Build encrypted string for registration. Used for cancel link or other services outside of Summit Events App
-                        String encryptedString = seaShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, eventInformation.registrationId);
+                        String encryptedString = SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, eventInformation.registrationId);
 
                         if (encryptedString.length() > 255) {
                             eventRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -244,7 +243,7 @@ public with sharing class SummitEventsConfirmationController {
                         SummitEventsShared SEAShared = new SummitEventsShared();
 
                         //Remove the registration ID from the cookie so back button will redirect to the correct page.
-                        SEAShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, '');
+                        SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, '');
                     } else {
                         ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'Hosted guest record(s) could not be saved.'));
                     }

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -37,7 +37,8 @@ public with sharing class SummitEventsConfirmationController {
                             Event_Home_Link_Title__c, Event_Home_Link_URL__c, Tracking_Confirmation_Registration__c, Event_Full_Text__c,
                             Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c, Hand_Raise_Action__c, Account__r.Name, Audience__c,
                             Filter_Category__c, Event_Sponsor__c, Event_Fee_Label__c, Event_Fee_Submit_List_Label__c, Event_Fee_Total_Label__c,
-                            Event_Fee__c, Event_Fee_Allocation__c, Event_Fee_Additional__c, Event_Fees_Received_Label__c
+                            Event_Fee__c, Event_Fee_Allocation__c, Event_Fee_Additional__c, Event_Fees_Received_Label__c, Event_Payment_Due_Description__c,
+                            Event_Payment_Due_Heading_Label__c, Event_Payment_Received_Heading_Label__c, Event_Payment_Received_Description__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -240,8 +240,6 @@ public with sharing class SummitEventsConfirmationController {
                         eventRegistration.Status__c = 'Registered';
                         eventRegistration = regCRUD.updateRegistration(eventRegistration);
 
-                        SummitEventsShared SEAShared = new SummitEventsShared();
-
                         //Remove the registration ID from the cookie so back button will redirect to the correct page.
                         SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, '');
                     } else {

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -11,12 +11,10 @@ public with sharing class SummitEventsConfirmationController {
     public String formattedNavDate { get; set; }
     public Boolean eventIsClosed { get; set; }
     public Summit_Events_Registration__c eventRegistration { get; set; }
-    public Map <String, String> feesByIndex { get; set; }
     public List<Summit_Events_Fee__c> eventFees { get; set; }
     public Double totalPaymentAmount { get; set; }
     public Double existingPaymentAmount { get; set; }
     public Double eventOnlyPaymentAmount { get; set; }
-    public Boolean hasFees { get; set; }
     public Boolean paymentReceived { get; set; }
 
     private class questionData {
@@ -33,7 +31,6 @@ public with sharing class SummitEventsConfirmationController {
     public SummitEventsConfirmationController() {
         eventIsClosed = false;
         eventInformation = SummitEventsShared.getSummitEventsInfo();
-
         if (!String.isEmpty(eventInformation.eventId)) {
             eventPage = [
                     SELECT Event_Confirmation_Title__c, Event_Name__c, Template__c, Event_Confirmation_Description__c, Event_Footer__c,
@@ -73,7 +70,7 @@ public with sharing class SummitEventsConfirmationController {
 
                 }
 
-                //gatherPaymentInformation();
+                gatherPaymentInformation();
 
             }
         }
@@ -91,8 +88,8 @@ public with sharing class SummitEventsConfirmationController {
         // Default to submit page, submit will redirect to beginning if no reg id is present. Prevents pre-filled forms in one step registrations.
         ApexPages.currentPage().getHeaders().put('referer', Page.SummitEventsSubmit.getUrl());
 
-        if (!eventIsClosed) {
-            if (!String.isBlank(eventInformation.registrationId)) {
+        if (!eventIsClosed && !eventInformation.valid.equalsIgnoreCase('false')) {
+            if (String.isNotBlank(eventInformation.registrationId)) {
 
                 Summit_Events_Registration__c eventRegistration = [
                         SELECT Id, Status__c, Event_Name__c, Event_Instance_Title__c, Guest_JSON__c, Event__r.Payment_Gateway__c
@@ -223,12 +220,15 @@ public with sharing class SummitEventsConfirmationController {
                     }
 
                     if (String.isNotBlank(eventRegistration.Event__r.Payment_Gateway__c) && eventRegistration.Event__r.Payment_Gateway__c != 'No Gateway') {
-                        pageRef = gatherPaymentInformation();
+                        pageRef = checkForPayment();
                     }
 
                     if (eventRegistrationSuccess && pageRef == null) {
                         //Build encrypted string for registration. Used for cancel link or other services outside of Summit Events App
-                        String encryptedString = SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, eventInformation.registrationId);
+                        //valid = false will not work for registration pages, only confirmation and cancel registration pages
+
+                        System.debug(eventInformation.registrationId);
+                        String encryptedString = SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, eventInformation.registrationId, false);
 
                         if (encryptedString.length() > 255) {
                             eventRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -240,11 +240,11 @@ public with sharing class SummitEventsConfirmationController {
                         eventRegistration.Status__c = 'Registered';
                         eventRegistration = regCRUD.updateRegistration(eventRegistration);
 
-                        //Remove the registration ID from the cookie so back button will redirect to the correct page.
-                        SummitEventsShared.createEncryptedCookie(eventInformation.audience, eventInformation.instanceId, eventInformation.eventId, '');
                     } else {
                         ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, 'Hosted guest record(s) could not be saved.'));
                     }
+
+
                 }
             }
 
@@ -252,11 +252,34 @@ public with sharing class SummitEventsConfirmationController {
         return pageRef;
     }
 
-    public PageReference gatherPaymentInformation() {
+    public PageReference checkForPayment() {
+        String errorMessage = '';
         PageReference pageRef = null;
+        List<Summit_Events_Payment__c> payments = [
+                SELECT Id, Payment_Amount__c
+                FROM Summit_Events_Payment__c
+                WHERE Event_Registration__c = :eventInformation.registrationId
+        ];
+        if (payments.size() > 0) {
+            paymentReceived = true;
+        } else if (payments.size() == 0) {
+            errorMessage = 'Payment was not received. Please try again.';
+        } else {
+            errorMessage = 'Multiple payments were received. Please contact event.';
+        }
+        if (String.isNotBlank(errorMessage)) {
+            pageRef = Page.SummitEventsSubmit;
+            pageRef.getParameters().put('error', EncodingUtil.urlEncode(errorMessage, 'UTF-8'));
+            pageRef.setRedirect(true);
+        }
+        return pageRef;
+    }
 
-        /* Check if there is a fee and a gateway set */
+    public void gatherPaymentInformation() {
         /** Collect Fees **/
+        eventOnlyPaymentAmount = 0;
+        totalPaymentAmount = 0;
+
         eventFees = [
                 SELECT Name, Event_Fee__c, Event_Fee_Allocation__c, Description__c, Event_Fee_Type__c, Summit_Events__c, Event_Appointment_Type__c,
                         Event_Appointment_Type__r.Title__c, Event_Fee_Allocation__r.Name
@@ -271,40 +294,22 @@ public with sharing class SummitEventsConfirmationController {
                 WHERE Event_Registration__c = :eventInformation.registrationId
         ];
 
-        String errorMessage = '';
+        for (Summit_Events_Fee__c fee : eventFees) {
+            if (fee.Event_Fee__c != null && fee.Event_Fee__c > 0) {
+                totalPaymentAmount += fee.Event_Fee__c;
+            }
+            if (fee.Event_Fee_Type__c == 'Event' || fee.Event_Fee_Type__c == 'Event Additional') {
+                eventOnlyPaymentAmount += fee.Event_Fee__c;
+            }
+
+        }
 
         if (payments.size() > 0) {
             paymentReceived = true;
             //Payment received. Get payment fees to display.
-            feesByIndex = new Map<String, String>();
-            eventOnlyPaymentAmount = 0;
-            totalPaymentAmount = 0;
-            for (Summit_Events_Fee__c fee : eventFees) {
-                if (fee.Event_Fee__c != null && fee.Event_Fee__c > 0) {
-                    totalPaymentAmount += fee.Event_Fee__c;
-                }
-                if (fee.Event_Fee_Type__c == 'Event' || fee.Event_Fee_Type__c == 'Event Additional') {
-                    eventOnlyPaymentAmount += fee.Event_Fee__c;
-                }
-
-            }
             existingPaymentAmount = payments[0].Payment_Amount__c;
             totalPaymentAmount = totalPaymentAmount - payments[0].Payment_Amount__c;
-            if (totalPaymentAmount > 0) {
-                hasFees = true;
-            }
-
-        } else if (payments.size() == 0) {
-            errorMessage = 'Payment was not received. Please try again.';
-        } else {
-            errorMessage = 'Multiple payments were received. Please contact event.';
         }
-        if (String.isNotBlank(errorMessage)) {
-            pageRef = Page.SummitEventsSubmit;
-            pageRef.getParameters().put('error', EncodingUtil.urlEncode(errorMessage, 'UTF-8'));
-            pageRef.setRedirect(true);
-        }
-        return pageRef;
     }
 
 

--- a/force-app/main/default/classes/SummitEventsDonationController.cls
+++ b/force-app/main/default/classes/SummitEventsDonationController.cls
@@ -5,8 +5,7 @@
 
 public with sharing class SummitEventsDonationController {
 
-    public SummitEventsShared seaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public Summit_Events_Instance__c eventInstance { get; set; }
     public String templateSelected { get; set; }
     public String donationAllocation { get; set; }
@@ -19,7 +18,7 @@ public with sharing class SummitEventsDonationController {
     public Map<String, PageReference> pageFlow {get;set;}
 
     public SummitEventsDonationController() {
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
 
         if (String.isNotBlank(eventInformation.eventId) && String.isNotBlank(eventInformation.instanceId)) {
 
@@ -42,9 +41,9 @@ public with sharing class SummitEventsDonationController {
                     WITH SECURITY_ENFORCED
             ];
 
-            pageFlow = seaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
+            pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
 
-            templateSelected = seaShared.getTemplate(eventPage.Template__c);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
             //Check for current donation fees for this registration
             List<Summit_Events_Fee__c> previousDonationFees = [
@@ -62,9 +61,9 @@ public with sharing class SummitEventsDonationController {
                 donationAmountSelect = String.valueOf(incomingFee.Event_Fee__c);
             }
 
-            eventIsClosed = seaShared.isEventClosed(eventInstance);
+            eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
-            formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
+            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
         }
     }
 
@@ -120,7 +119,7 @@ public with sharing class SummitEventsDonationController {
     }
 
     public PageReference checkEventDetails() {
-        return seaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
     public PageReference submitDonation() {

--- a/force-app/main/default/classes/SummitEventsDonationController.cls
+++ b/force-app/main/default/classes/SummitEventsDonationController.cls
@@ -119,7 +119,7 @@ public with sharing class SummitEventsDonationController {
     }
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('donation');
     }
 
     public PageReference submitDonation() {

--- a/force-app/main/default/classes/SummitEventsFeed.cls
+++ b/force-app/main/default/classes/SummitEventsFeed.cls
@@ -8,7 +8,6 @@
 global with sharing class SummitEventsFeed {
 
     private static String feedType { get; set; }
-    private static final SummitEventsShared seaShared = new SummitEventsShared();
     private static Id recTypeId { get; set; }
     private static String namespace { get; set; }
 
@@ -283,35 +282,33 @@ global with sharing class SummitEventsFeed {
         eventQuery += ' WITH SECURITY_ENFORCED ';
         eventQuery += ' ORDER BY Instance_Start_Date__c, Instance_Start_Time__c ';
 
-        System.debug(eventQuery);
-
         List<Summit_Events_Instance__c> EventInstanceList = Database.query(eventQuery);
 
         Datetime regDateOpenDate = null;
         for (Summit_Events_Instance__c eventInstance : EventInstanceList) {
             regDateOpenDate = Datetime.now().addDays(-1);
             if (eventInstance.Event__r.Close_Event_Days_Before__c != null && eventInstance.Event__r.Close_Event_Days_Before__c != 0) {
-                regDateOpenDate = seaShared.adjustForTimeZone(Datetime.now(), eventInstance.Instance_Time_Zone__c);
+                regDateOpenDate = SummitEventsShared.adjustForTimeZone(Datetime.now(), eventInstance.Instance_Time_Zone__c);
                 regDateOpenDate = regDateOpenDate.addDays((Integer.valueOf(eventInstance.Event__r.Close_Event_Days_Before__c) + 1));
             }
             eventItem evt = new eventItem();
             evt.ID = eventInstance.Id;
 
             if (eventInstance.Event__r.Event_Name__c != null) {
-                evt.title = seaShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
-                evt.title_event = seaShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
+                evt.title = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
+                evt.title_event = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Event_Name__c, true);
             } else {
-                evt.title = seaShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
-                evt.title_event = seaShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
+                evt.title = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
+                evt.title_event = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Name, true);
             }
 
             if (String.isNotBlank(eventInstance.Instance_Title__c)) {
-                evt.title += ' - ' + seaShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
-                evt.title_instance = seaShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
+                evt.title += ' - ' + SummitEventsShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
+                evt.title_instance = SummitEventsShared.removeHTMLandEscape(eventInstance.Instance_Title__c, true);
             }
 
             if (String.isNotBlank(eventInstance.Instance_Short_Description__c)) {
-                evt.instanceDesc = seaShared.removeHTMLandEscape(eventInstance.Instance_Short_Description__c, true);
+                evt.instanceDesc = SummitEventsShared.removeHTMLandEscape(eventInstance.Instance_Short_Description__c, true);
             } else {
                 evt.instanceDesc = '';
             }
@@ -323,9 +320,9 @@ global with sharing class SummitEventsFeed {
 //            }
 
             if (String.isNotBlank(eventInstance.Feed_Registration_Button_Text_Override__c)) {
-                evt.feedButtonText = seaShared.removeHTMLandEscape(eventInstance.Feed_Registration_Button_Text_Override__c, true);
+                evt.feedButtonText = SummitEventsShared.removeHTMLandEscape(eventInstance.Feed_Registration_Button_Text_Override__c, true);
             } else if (String.isNotBlank(eventInstance.Event__r.Feed_Registration_Button_Text__c)) {
-                evt.feedButtonText = seaShared.removeHTMLandEscape(eventInstance.Event__r.Feed_Registration_Button_Text__c, true);
+                evt.feedButtonText = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Feed_Registration_Button_Text__c, true);
             } else {
                 evt.feedButtonText = 'Register';
             }
@@ -335,7 +332,7 @@ global with sharing class SummitEventsFeed {
             }
 
             if (String.isNotBlank(eventInstance.Location_Type_Override__c)) {
-                evt.locationType = seaShared.removeHTMLandEscape(eventInstance.Location_Type_Override__c, true);
+                evt.locationType = SummitEventsShared.removeHTMLandEscape(eventInstance.Location_Type_Override__c, true);
             } else if (String.isNotBlank(eventInstance.Event__r.Location_Type__c)) {
                 evt.locationType = eventInstance.Event__r.Location_Type__c;
             } else {
@@ -355,7 +352,7 @@ global with sharing class SummitEventsFeed {
             }
 
             if (String.isNotBlank(eventInstance.Event__r.Event_Short_Listing_Description__c)) {
-                evt.description = seaShared.removeHTMLandEscape(eventInstance.Event__r.Event_Short_Listing_Description__c, true);
+                evt.description = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Event_Short_Listing_Description__c, true);
             } else {
                 evt.description = '';
             }
@@ -379,18 +376,18 @@ global with sharing class SummitEventsFeed {
             }
 
             if (eventInstance.Instance_Start_Date__c != null) {
-                evt.start = seaShared.convertDateToDatetime(eventInstance.Instance_Start_Date__c, eventInstance.Instance_Start_Time__c, '');
+                evt.start = SummitEventsShared.convertDateToDatetime(eventInstance.Instance_Start_Date__c, eventInstance.Instance_Start_Time__c, '');
 
             }
             if (eventInstance.Instance_End_Date__c != null) {
-                evt.endDate = seaShared.convertDateToDatetime(eventInstance.Instance_End_Date__c, eventInstance.Instance_End_Time__c, '');
+                evt.endDate = SummitEventsShared.convertDateToDatetime(eventInstance.Instance_End_Date__c, eventInstance.Instance_End_Time__c, '');
             }
 
             if (String.isNotBlank(eventInstance.Event__r.Location_Title__c) || String.isNotBlank(eventInstance.Location_Title_Override__c)) {
                 if (String.isNotBlank(eventInstance.Location_Title_Override__c)) {
-                    evt.locationTitle = seaShared.removeHTMLandEscape(eventInstance.Location_Title_Override__c, true);
+                    evt.locationTitle = SummitEventsShared.removeHTMLandEscape(eventInstance.Location_Title_Override__c, true);
                 } else {
-                    evt.locationTitle = seaShared.removeHTMLandEscape(eventInstance.Event__r.Location_Title__c, true);
+                    evt.locationTitle = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Location_Title__c, true);
                 }
             } else {
                 evt.locationTitle = '';
@@ -398,9 +395,9 @@ global with sharing class SummitEventsFeed {
 
             if (String.isNotBlank(eventInstance.Event__r.Location_Address__c) || !String.isBlank(eventInstance.Location_Address_Override__c)) {
                 if (String.isNotBlank(eventInstance.Location_Address_Override__c)) {
-                    evt.locationAddress = seaShared.removeHTMLandEscape(eventInstance.Location_Address_Override__c, true);
+                    evt.locationAddress = SummitEventsShared.removeHTMLandEscape(eventInstance.Location_Address_Override__c, true);
                 } else {
-                    evt.locationAddress = seaShared.removeHTMLandEscape(eventInstance.Event__r.Location_Address__c, true);
+                    evt.locationAddress = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Location_Address__c, true);
                 }
             } else {
                 evt.locationAddress = '';
@@ -408,15 +405,15 @@ global with sharing class SummitEventsFeed {
 
             if (String.isNotBlank(eventInstance.Event__r.Location_Map_Link__c) || String.isNotBlank(eventInstance.Location_Map_Link_Override__c)) {
                 if (!String.isBlank(eventInstance.Location_Map_Link_Override__c)) {
-                    evt.locationMapLink = seaShared.removeHTMLandEscape(eventInstance.Location_Map_Link_Override__c, false);
+                    evt.locationMapLink = SummitEventsShared.removeHTMLandEscape(eventInstance.Location_Map_Link_Override__c, false);
                 } else {
-                    evt.locationMapLink = seaShared.removeHTMLandEscape(eventInstance.Event__r.Location_Map_Link__c, false);
+                    evt.locationMapLink = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Location_Map_Link__c, false);
                 }
             } else {
                 evt.locationMapLink = '';
             }
 
-            if (seaShared.isEventClosed(eventInstance)) {
+            if (SummitEventsShared.isEventClosed(eventInstance)) {
                 evt.eventClosed = true;
                 evt.eventUrl = 'javascript:;';
                 evt.className = 'eventClosed';
@@ -427,9 +424,9 @@ global with sharing class SummitEventsFeed {
                 evt.eventClosed = false;
                 if (!String.isBlank(eventInstance.Event__r.Alternate_Registration_URL__c) || !String.isBlank(eventInstance.Alternate_Registration_URL_Override__c)) {
                     if (!String.isBlank(eventInstance.Alternate_Registration_URL_Override__c)) {
-                        evt.eventUrl = seaShared.removeHTMLandEscape(eventInstance.Alternate_Registration_URL_Override__c, false);
+                        evt.eventUrl = SummitEventsShared.removeHTMLandEscape(eventInstance.Alternate_Registration_URL_Override__c, false);
                     } else {
-                        evt.eventUrl = seaShared.removeHTMLandEscape(eventInstance.Event__r.Alternate_Registration_URL__c, false);
+                        evt.eventUrl = SummitEventsShared.removeHTMLandEscape(eventInstance.Event__r.Alternate_Registration_URL__c, false);
                     }
 
                 } else {

--- a/force-app/main/default/classes/SummitEventsInfo.cls
+++ b/force-app/main/default/classes/SummitEventsInfo.cls
@@ -9,4 +9,5 @@ public with sharing class SummitEventsInfo {
     public String eventId { get; set; }
     public String registrationId { get; set; }
     public String dt { get; set; }
+    public String valid { get; set; }
 }

--- a/force-app/main/default/classes/SummitEventsInfo.cls
+++ b/force-app/main/default/classes/SummitEventsInfo.cls
@@ -1,0 +1,12 @@
+// Copyright (c) 2020, Salesforce.org. All rights reserved.
+// Use of this source code is governed by a BSD 3-Clause.
+// License can be found found in the LICENSE file in this repository.
+// Created by Thaddaeus Dahlberg on 7/22/2023.
+
+public with sharing class SummitEventsInfo {
+    public String audience { get; set; }
+    public String instanceId { get; set; }
+    public String eventId { get; set; }
+    public String registrationId { get; set; }
+    public String dt { get; set; }
+}

--- a/force-app/main/default/classes/SummitEventsInfo.cls-meta.xml
+++ b/force-app/main/default/classes/SummitEventsInfo.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SummitEventsParkingPassController.cls
+++ b/force-app/main/default/classes/SummitEventsParkingPassController.cls
@@ -7,9 +7,7 @@ public with sharing class SummitEventsParkingPassController {
     public String firstName { get; set; }
     public String warning { get; set; }
     public Summit_Events_Registration__c visitor { get; set; }
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
-    private SummitEventsShared SEShared = new SummitEventsShared();
-
+    public SummitEventsInfo eventInformation { get; set; }
 
     public SummitEventsParkingPassController() {
         warning = 'Sorry, this parking permit has expired or invalid.';
@@ -17,11 +15,11 @@ public with sharing class SummitEventsParkingPassController {
         visitor = new Summit_Events_Registration__c();
 
         if (!String.isBlank(eventParameter)) {
-            String decryptedParameter = SEShared.decryptString(eventParameter, false);
+            String decryptedParameter = SummitEventsShared.decryptString(eventParameter, false);
 
             if (String.isNotBlank(decryptedParameter)) {
                 try {
-                    eventInformation = (SummitEventsShared.SummitEventsInfo) JSON.deserialize(decryptedParameter, SummitEventsShared.SummitEventsInfo.class);
+                    eventInformation = (SummitEventsInfo) JSON.deserialize(decryptedParameter, SummitEventsInfo.class);
                 } catch (Exception e) {
                     System.debug(e.getMessage());
                 }
@@ -37,7 +35,7 @@ public with sharing class SummitEventsParkingPassController {
                     System.debug(e.getMessage());
                 }
 
-                Datetime todayDateTime = SEShared.adjustForTimeZone(Datetime.now(), visitor.Event_Instance_Time_Zone__c);
+                Datetime todayDateTime = SummitEventsShared.adjustForTimeZone(Datetime.now(), visitor.Event_Instance_Time_Zone__c);
                 Date todayDate = Date.newInstance(todayDateTime.year(), todayDateTime.month(), todayDateTime.day());
 
                 if (todayDate <= visitor.Event_Instance_Start_Date__c && visitor.Status__c != 'Started' && visitor.Status__c != 'Cancelled') {

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -4,8 +4,7 @@
 // Created by Thaddaeus Dahlberg on 5/1/2018.
 
 public with sharing class SummitEventsRegisterAppointmentCtlr {
-    public SummitEventsShared seaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public Map<Id, Summit_Events_Appointment_Type__c> appointments { get; set; }
     public List<Summit_Events_Appointments__c> chosenApps { get; set; }
     public Summit_Events_Instance__c evtInstance { get; set; }
@@ -37,7 +36,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
     public SummitEventsRegisterAppointmentCtlr() {
         eventIsClosed = false;
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
         noOptionalAppointments = true;
 
         Map<String, Integer> appCount = new Map<String, Integer>();
@@ -53,7 +52,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                     WITH SECURITY_ENFORCED
             ];
 
-            templateSelected = seaShared.getTemplate(eventPage.Template__c);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
             if (!String.isBlank(eventInformation.registrationId)) {
                 evtInstance = [
@@ -65,12 +64,12 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                         WITH SECURITY_ENFORCED
                 ];
 
-                pageFlow = seaShared.getPageFlow(eventInformation.eventId, evtInstance.Instance_Title__c, ApexPages.currentPage(), evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c);
+                pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, evtInstance.Instance_Title__c, ApexPages.currentPage(), evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c);
 
-                eventIsClosed = seaShared.isEventClosed(evtInstance);
+                eventIsClosed = SummitEventsShared.isEventClosed(evtInstance);
 
                 if (evtInstance != null) {
-                    String dayOfWeek = seaShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
+                    String dayOfWeek = SummitEventsShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
                     // = dayOfWeek;
                     //Build available appointments
                     appointments = new Map<Id, Summit_Events_Appointment_Type__c>([
@@ -88,7 +87,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                             ORDER BY Sort_Order__c ASC NULLS LAST
                     ]);
 
-                    formattedNavDate = seaShared.navBreadcrumbBuilder(evtInstance);
+                    formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(evtInstance);
 
                     //Check if the user gets to select any appointments or they are all auto added
 
@@ -112,7 +111,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
                     //Add the chosen state appointments
                     for (Integer x = 0; x < chosenApps.size(); x++) {
-                        chosenApps[x].Description__c = seaShared.removeHTMLandEscape(chosenApps[x].Description__c, false);
+                        chosenApps[x].Description__c = SummitEventsShared.removeHTMLandEscape(chosenApps[x].Description__c, false);
                         //Keep track of appointment ids to not show in available appointments later
                         if (!String.isBlank(chosenApps[x].Event_Appointment_Type__c)) {
                             if (!appCount.containsKey(chosenApps[x].Event_Appointment_Type__c)) {
@@ -156,7 +155,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                             }
 
                             if (apt.Appointment_Category__c != null) {
-                                Map<String, String> dependencies = seaShared.getDependentSelectOptions('Summit_Events_Appointment_Type__c', 'Appointment_Category__c', 'Appointment_Type__c', apt.Appointment_Category__c);
+                                Map<String, String> dependencies = SummitEventsShared.getDependentSelectOptions('Summit_Events_Appointment_Type__c', 'Appointment_Category__c', 'Appointment_Type__c', apt.Appointment_Category__c);
                                 List<String> pickListItems = new List<String>();
                                 System.debug(dependencies);
                                 if (dependencies.size() > 0) {
@@ -193,7 +192,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
 
     public PageReference checkEventDetails() {
-        return seaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
     public PageReference saveOptions() {

--- a/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterAppointmentCtlr.cls
@@ -157,7 +157,6 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
                             if (apt.Appointment_Category__c != null) {
                                 Map<String, String> dependencies = SummitEventsShared.getDependentSelectOptions('Summit_Events_Appointment_Type__c', 'Appointment_Category__c', 'Appointment_Type__c', apt.Appointment_Category__c);
                                 List<String> pickListItems = new List<String>();
-                                System.debug(dependencies);
                                 if (dependencies.size() > 0) {
                                     for (String item : dependencies.keySet()) {
                                         pickListItems.add(dependencies.get(item));
@@ -192,7 +191,7 @@ public with sharing class SummitEventsRegisterAppointmentCtlr {
 
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('appointment');
     }
 
     public PageReference saveOptions() {

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -8,8 +8,7 @@ public with sharing class SummitEventsRegisterController {
     public Summit_Events__c eventPage { get; set; }
     public List<SelectOption> guestAmt { get; set; }
     public Summit_Events_Registration__c eventRegistration { get; set; }
-    private final SummitEventsShared SeaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public String templateSelected { get; set; }
     public Boolean contactSet { get; set; }
     public Boolean eventIsClosed { get; set; }
@@ -52,7 +51,7 @@ public with sharing class SummitEventsRegisterController {
         additionalQuestions = false;
         EvtUserType = UserInfo.getUserType();
         //Get cookie or URL string variable
-        eventInformation = SeaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
 
         //Create event registration. Populate with current registration if it exists with removed id
         eventRegistration = new Summit_Events_Registration__c();
@@ -107,8 +106,8 @@ public with sharing class SummitEventsRegisterController {
 
             //define Event ID from instanceInfo data
             eventInformation.eventId = evtInstance.Event__r.Id;
-            startTimeString = SeaShared.formatTime(evtInstance.Instance_Start_Time__c, false);
-            endTimeString = SeaShared.formatTime(evtInstance.Instance_End_Time__c, false);
+            startTimeString = SummitEventsShared.formatTime(evtInstance.Instance_Start_Time__c, false);
+            endTimeString = SummitEventsShared.formatTime(evtInstance.Instance_End_Time__c, false);
         }
 
         //Get Event Info off of instance master detail id
@@ -141,7 +140,7 @@ public with sharing class SummitEventsRegisterController {
                     WITH SECURITY_ENFORCED
             ];
 
-            pageFlow = SeaShared.getPageFlow(eventInformation.eventId, evtInstance.Instance_Title__c, ApexPages.currentPage(), evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c);
+            pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, evtInstance.Instance_Title__c, ApexPages.currentPage(), evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c);
             nextUrl = pageFlow.get('Next').getUrl().toLowerCase();
 
             if (String.isNotBlank(eventPage.Ask_Phone__c)) {
@@ -161,7 +160,7 @@ public with sharing class SummitEventsRegisterController {
                 }
             }
 
-            eventIsClosed = SeaShared.isEventClosed(evtInstance);
+            eventIsClosed = SummitEventsShared.isEventClosed(evtInstance);
 
             if (
                     (String.isNotBlank(eventPage.Add_Info_Question_Type_1__c) && String.isNotBlank(eventPage.Add_Info_Question_Text_1__c)) ||
@@ -208,10 +207,10 @@ public with sharing class SummitEventsRegisterController {
                 locationAddress = eventPage.Location_Title__c;
             }
 
-            formattedNavDate = SeaShared.navBreadcrumbBuilder(evtInstance);
+            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(evtInstance);
 
             //Grab the template if defined
-            templateSelected = SeaShared.getTemplate(eventPage.Template__c);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
             if (eventPage.Allow_Other_Attendees__c) {
                 guestAmt = new List<SelectOption>();
@@ -364,7 +363,7 @@ public with sharing class SummitEventsRegisterController {
     }
 
     public PageReference checkEventDetails() {
-        return SeaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
     public List<SelectOption> getSexDD() {
@@ -374,7 +373,7 @@ public with sharing class SummitEventsRegisterController {
     public List<SelectOption> getStateDD() {
         List<SelectOption> pickListItems = new List<SelectOption>();
         if (String.isNotBlank(eventRegistration.Registrant_Country__c)) {
-            Map<String, String> dependencies = SeaShared.getDependentSelectOptions('Summit_Events_Registration__c', 'Registrant_Country__c', 'Registrant_State_Global__c', eventRegistration.Registrant_Country__c);
+            Map<String, String> dependencies = SummitEventsShared.getDependentSelectOptions('Summit_Events_Registration__c', 'Registrant_Country__c', 'Registrant_State_Global__c', eventRegistration.Registrant_Country__c);
             if (dependencies.size() > 1) {
                 pickListItems.add(new SelectOption('', 'Select...'));
                 for (String item : dependencies.keySet()) {
@@ -429,7 +428,7 @@ public with sharing class SummitEventsRegisterController {
             picklistString = picklistString.trim();
             picklistString = picklistString.replace('\n\n', '\n');
             pickList = picklistString.split('\n');
-            System.debug(picklist);
+            System.debug(pickList);
         }
         return pickList;
     }
@@ -540,7 +539,7 @@ public with sharing class SummitEventsRegisterController {
         }
 
         eventRegistration.Status__c = 'Started';
-        eventRegistration.Event_Instance_Date_Time_Formatted__c = SeaShared.navBreadcrumbBuilder(evtInstance);
+        eventRegistration.Event_Instance_Date_Time_Formatted__c = SummitEventsShared.navBreadcrumbBuilder(evtInstance);
         eventRegistration.Event__c = eventInformation.eventId;
         eventRegistration.Event_Instance__c = eventInformation.instanceId;
 
@@ -548,7 +547,7 @@ public with sharing class SummitEventsRegisterController {
 
         eventInformation.registrationId = eventRegistration.Id;
 
-        String dayOfWeek = SeaShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
+        String dayOfWeek = SummitEventsShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
         //Insert pre-chosen appointments for appointments page
         List<Summit_Events_Appointment_Type__c> autoAddAppt = [
                 SELECT Id, Name, Title__c, Description__c, Appointment_Type__c, Appointment_Category__c, Registrant_Input__c, Custom_Picklist__c, Appointment_Limits__c,
@@ -646,7 +645,7 @@ public with sharing class SummitEventsRegisterController {
 
             //Update encrypted cookie
             SummitEventsShared SeaShared = new SummitEventsShared();
-            SeaShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id);
+            SummitEventsShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id);
 
             return eventRegistration;
         }

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -619,7 +619,6 @@ public with sharing class SummitEventsRegisterController {
             }
 
             //Update encrypted cookie
-            SummitEventsShared SeaShared = new SummitEventsShared();
             SummitEventsShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id);
 
             return eventRegistration;

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -221,11 +221,11 @@ public with sharing class SummitEventsRegisterController {
                 }
             }
 
-            addPick1 = createPicklists(eventPage.Add_Info_Question_Pick_List_1__c, eventPage.Add_Info_Question_Pick_List_Long_1__c);
-            addPick2 = createPicklists(eventPage.Add_Info_Question_Pick_List_2__c, eventPage.Add_Info_Question_Pick_List_Long_2__c);
-            addPick3 = createPicklists(eventPage.Add_Info_Question_Pick_List_3__c, eventPage.Add_Info_Question_Pick_List_Long_3__c);
-            addPick4 = createPicklists(eventPage.Add_Info_Question_Pick_List_4__c, eventPage.Add_Info_Question_Pick_List_Long_4__c);
-            addPick5 = createPicklists(eventPage.Add_Info_Question_Pick_List_5__c, eventPage.Add_Info_Question_Pick_List_Long_5__c);
+            addPick1 = SummitEventsShared.createPicklistsFromStrings(eventPage.Add_Info_Question_Pick_List_1__c, eventPage.Add_Info_Question_Pick_List_Long_1__c);
+            addPick2 = SummitEventsShared.createPicklistsFromStrings(eventPage.Add_Info_Question_Pick_List_2__c, eventPage.Add_Info_Question_Pick_List_Long_2__c);
+            addPick3 = SummitEventsShared.createPicklistsFromStrings(eventPage.Add_Info_Question_Pick_List_3__c, eventPage.Add_Info_Question_Pick_List_Long_3__c);
+            addPick4 = SummitEventsShared.createPicklistsFromStrings(eventPage.Add_Info_Question_Pick_List_4__c, eventPage.Add_Info_Question_Pick_List_Long_4__c);
+            addPick5 = SummitEventsShared.createPicklistsFromStrings(eventPage.Add_Info_Question_Pick_List_5__c, eventPage.Add_Info_Question_Pick_List_Long_5__c);
 
             //Calculate event cost by Instance and Event fees and add to list of fees for upsert
             eventFeeList = new List<Summit_Events_Fee__c>();
@@ -406,31 +406,6 @@ public with sharing class SummitEventsRegisterController {
 
     public List<SelectOption> getPronounDD() {
         return PickThePicklist('Summit_Events_Registration__c', 'Registrant_Pronouns__c', true);
-    }
-
-    public List<SelectOption> createPicklists(String returnSepStringList, String returnSepStringList2) {
-        List<SelectOption> cpl = new List<SelectOption>();
-        cpl.add(new SelectOption('', 'Select...'));
-        List<String> splitList = new List<String>();
-        splitList.addAll(sanitizePicklistString(returnSepStringList));
-        splitList.addAll(sanitizePicklistString(returnSepStringList2));
-        System.debug(splitList);
-        for (String p : splitList) {
-            p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
-            cpl.add(new SelectOption(p, p));
-        }
-        return cpl;
-    }
-
-    public List<String> sanitizePicklistString(String picklistString) {
-        List<String> pickList = new List<String>();
-        if (String.isNotBlank(picklistString)) {
-            picklistString = picklistString.trim();
-            picklistString = picklistString.replace('\n\n', '\n');
-            pickList = picklistString.split('\n');
-            System.debug(pickList);
-        }
-        return pickList;
     }
 
     public List<SelectOption> PickThePicklist(String YourObjectName, String YourFieldName, Boolean includeSelect) {

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -70,7 +70,6 @@ public with sharing class SummitEventsRegisterController {
         //Set the default country if it is in settings and matches something in the global pick list
         Summit_Events_Settings__c seaCustomSettings = Summit_Events_Settings__c.getOrgDefaults();
         String defaultCountry = seaCustomSettings.Default_Country__c;
-        System.debug(defaultCountry);
         if (String.isNotBlank(defaultCountry) && String.isBlank(eventRegistration.Registrant_Country__c)) {
             List<SelectOption> getCountryDD = PickThePicklist('Summit_Events_Registration__c', 'Registrant_Country__c', false);
             for (SelectOption selectOption : getCountryDD) {
@@ -80,7 +79,6 @@ public with sharing class SummitEventsRegisterController {
                 }
             }
         }
-        System.debug(eventRegistration.Registrant_Country__c);
 
         //Set applicant type if audience is passed
         registrantAudience = eventInformation.audience;
@@ -136,7 +134,8 @@ public with sharing class SummitEventsRegisterController {
                             Phone_Label__c, Phone_Type_Label__c, Preferred_First_Name_Label__c, Pronouns_Label__c, Registrant_Receive_Texts_Label__c,
                             Relationship_To_Institution_Label__c, Third_Party_Registrant_Label__c, Title_Label__c, Preferred_Class_Year_Label__c,
                             Registrant_Relationship_Label__c, Event_Fee_Label__c, Event_Fee_Total_Label__c, Event_Fee_Submit_List_Label__c, Account__r.Name,
-                            Filter_Category__c, Do_not_show_receive_text_question__c
+                            Filter_Category__c, Do_not_show_receive_text_question__c, Add_Info_Question_Pick_List_Long_1__c, Add_Info_Question_Pick_List_Long_2__c,
+                            Add_Info_Question_Pick_List_Long_3__c, Add_Info_Question_Pick_List_Long_4__c, Add_Info_Question_Pick_List_Long_5__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED
@@ -223,11 +222,11 @@ public with sharing class SummitEventsRegisterController {
                 }
             }
 
-            addPick1 = createPicklists(eventPage.Add_Info_Question_Pick_List_1__c);
-            addPick2 = createPicklists(eventPage.Add_Info_Question_Pick_List_2__c);
-            addPick3 = createPicklists(eventPage.Add_Info_Question_Pick_List_3__c);
-            addPick4 = createPicklists(eventPage.Add_Info_Question_Pick_List_4__c);
-            addPick5 = createPicklists(eventPage.Add_Info_Question_Pick_List_5__c);
+            addPick1 = createPicklists(eventPage.Add_Info_Question_Pick_List_1__c, eventPage.Add_Info_Question_Pick_List_Long_1__c);
+            addPick2 = createPicklists(eventPage.Add_Info_Question_Pick_List_2__c, eventPage.Add_Info_Question_Pick_List_Long_2__c);
+            addPick3 = createPicklists(eventPage.Add_Info_Question_Pick_List_3__c, eventPage.Add_Info_Question_Pick_List_Long_3__c);
+            addPick4 = createPicklists(eventPage.Add_Info_Question_Pick_List_4__c, eventPage.Add_Info_Question_Pick_List_Long_4__c);
+            addPick5 = createPicklists(eventPage.Add_Info_Question_Pick_List_5__c, eventPage.Add_Info_Question_Pick_List_Long_5__c);
 
             //Calculate event cost by Instance and Event fees and add to list of fees for upsert
             eventFeeList = new List<Summit_Events_Fee__c>();
@@ -410,19 +409,29 @@ public with sharing class SummitEventsRegisterController {
         return PickThePicklist('Summit_Events_Registration__c', 'Registrant_Pronouns__c', true);
     }
 
-    public List<SelectOption> createPicklists(String returnSepStringList) {
+    public List<SelectOption> createPicklists(String returnSepStringList, String returnSepStringList2) {
         List<SelectOption> cpl = new List<SelectOption>();
-        if (!String.isBlank(returnSepStringList)) {
-            cpl.add(new SelectOption('', 'Select...'));
-            returnSepStringList = returnSepStringList.trim();
-            returnSepStringList = returnSepStringList.replace('\n\n', '\n');
-            String[] splitList = returnSepStringList.split('\n');
-            for (String p : splitList) {
-                p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
-                cpl.add(new SelectOption(p, p));
-            }
+        cpl.add(new SelectOption('', 'Select...'));
+        List<String> splitList = new List<String>();
+        splitList.addAll(sanitizePicklistString(returnSepStringList));
+        splitList.addAll(sanitizePicklistString(returnSepStringList2));
+        System.debug(splitList);
+        for (String p : splitList) {
+            p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
+            cpl.add(new SelectOption(p, p));
         }
         return cpl;
+    }
+
+    public List<String> sanitizePicklistString(String picklistString) {
+        List<String> pickList = new List<String>();
+        if (String.isNotBlank(picklistString)) {
+            picklistString = picklistString.trim();
+            picklistString = picklistString.replace('\n\n', '\n');
+            pickList = picklistString.split('\n');
+            System.debug(picklist);
+        }
+        return pickList;
     }
 
     public List<SelectOption> PickThePicklist(String YourObjectName, String YourFieldName, Boolean includeSelect) {

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -363,7 +363,7 @@ public with sharing class SummitEventsRegisterController {
     }
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('register');
     }
 
     public List<SelectOption> getSexDD() {
@@ -619,7 +619,7 @@ public with sharing class SummitEventsRegisterController {
             }
 
             //Update encrypted cookie
-            SummitEventsShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id);
+            SummitEventsShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id, true);
 
             return eventRegistration;
         }

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -174,7 +174,6 @@ public with sharing class SummitEventsRegisterGuestsController {
     public List<Map<String, String>> createPicklists(String pickListString, String pickListString2) {
         List<Map<String, String>> cpl = new List<Map<String, String>>();
         List<SelectOption> splitList = SummitEventsShared.createPicklistsFromStrings(pickListString, pickListString2);
-        System.debug(splitList);
         for (SelectOption p : splitList) {
             cpl.add(new Map<String, String>{
                     p.getLabel() => p.getValue()
@@ -212,7 +211,7 @@ public with sharing class SummitEventsRegisterGuestsController {
     }
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('guest');
     }
 
     public PageReference saveGuests() {

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -59,7 +59,8 @@ public with sharing class SummitEventsRegisterGuestsController {
                             Tracking_Submit_Registration__c, Event_Full_Text__c, Close_Event_Days_Before__c, Keep_Registration_Open_During_Event__c,
                             Guest_Registration_Title__c, Guest_Max_Amount__c, Guest_Registration_Description__c, Guest_Table_Size__c, Guest_Tables_Available__c,
                             Display_Guest_Registration__c, Guest_Registration_Add_Button_Label__c, No_Guest_Registrations_Added_Message__c,
-                            Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c
+                            Account__r.Name, Audience__c, Filter_Category__c, Event_Sponsor__c, Guest_Unsaved_Cancel_Label__c, Guest_Unsaved_Continue_Label__c,
+                            Guest_Unsaved_Modal_Text__c
                     FROM Summit_Events__c
                     WHERE Id = :eventInformation.eventId
                     WITH SECURITY_ENFORCED

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -76,7 +76,7 @@ public with sharing class SummitEventsRegisterGuestsController {
             eventGuestQuestions = new Map<Id, Summit_Events_Question__c>([
                     SELECT Name, Question_Label__c, Question_Field_Type__c, Default_Value__c, Registrant_Type__c, Instructions__c, Help_Text__c, Display_Order__c,
                             Map_to_Field__c, Picklist_Values__c, Text_Limit__c, Controlling_Question__c, Controlling_Logic__c, Required__c, Is_Visible__c, Error_Assist_Text__c,
-                            Existing_Picklist_Values__c
+                            Existing_Picklist_Values__c, Picklist_Values_Long__c
                     FROM Summit_Events_Question__c
                     WHERE Event__c = :eventInformation.eventId
                     AND (Registrant_Type__c = 'Guest' OR Registrant_Type__c = 'Registrant and Guest')
@@ -103,8 +103,8 @@ public with sharing class SummitEventsRegisterGuestsController {
                 q.required = seaQuestion.Required__c;
                 if (String.isNotBlank(seaQuestion.Existing_Picklist_Values__c)) {
                     q.picklist = createExistingPicklist(seaQuestion.Existing_Picklist_Values__c);
-                } else if (String.isNotBlank(seaQuestion.Picklist_Values__c)) {
-                    q.picklist = createPicklists(seaQuestion.Picklist_Values__c);
+                } else if (String.isNotBlank(seaQuestion.Picklist_Values__c) || String.isNotBlank(seaQuestion.Picklist_Values_Long__c)) {
+                    q.picklist = createPicklists(seaQuestion.Picklist_Values__c, seaQuestion.Picklist_Values_Long__c);
                 }
                 q.help = seaQuestion.Help_Text__c;
                 q.instructions = seaQuestion.Instructions__c;
@@ -170,21 +170,14 @@ public with sharing class SummitEventsRegisterGuestsController {
         }
     }
 
-    public List<Map<String, String>> createPicklists(String returnSepStringList) {
+    public List<Map<String, String>> createPicklists(String pickListString, String pickListString2) {
         List<Map<String, String>> cpl = new List<Map<String, String>>();
-        if (!String.isBlank(returnSepStringList)) {
+        List<SelectOption> splitList = SummitEventsShared.createPicklistsFromStrings(pickListString, pickListString2);
+        System.debug(splitList);
+        for (SelectOption p : splitList) {
             cpl.add(new Map<String, String>{
-                    'Select...' => ''
+                    p.getLabel() => p.getValue()
             });
-            returnSepStringList = returnSepStringList.trim();
-            returnSepStringList = returnSepStringList.replace('\n\n', '\n');
-            String[] splitList = returnSepStringList.split('\n');
-            for (String p : splitList) {
-                p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
-                cpl.add(new Map<String, String>{
-                        p => p
-                });
-            }
         }
         return cpl;
     }

--- a/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterGuestsController.cls
@@ -5,8 +5,7 @@
 
 public with sharing class SummitEventsRegisterGuestsController {
 
-    public SummitEventsShared seaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public String formattedNavDate { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public Summit_Events_Instance__c eventInstance { get; set; }
@@ -49,7 +48,7 @@ public with sharing class SummitEventsRegisterGuestsController {
     }
 
     public SummitEventsRegisterGuestsController() {
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
         String namespace = SummitEventsNamespace.getNamespace();
         if (String.isNotBlank(namespace)) {
             namespace = namespace.toLowerCase() + '__';
@@ -94,10 +93,10 @@ public with sharing class SummitEventsRegisterGuestsController {
                 //Check all mapTo fields before adding question
                 q.setupFail = false;
                 q.setupError = '';
-                q.setupError = seaShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', eventGuestQuestions.get(key).Map_to_Field__c, '', true, '');
+                q.setupError = SummitEventsShared.checkFieldGuestAccess(namespace + 'Summit_Events_Registration__c', eventGuestQuestions.get(key).Map_to_Field__c, '', true, '');
                 q.name = seaQuestion.Name;
                 q.question = seaQuestion.Question_Label__c;
-                q.id = seaShared.encryptString(seaQuestion.Id);
+                q.id = SummitEventsShared.encryptString(seaQuestion.Id);
                 q.name = seaQuestion.Name;
                 q.question = seaQuestion.Question_Label__c;
                 q.type = seaQuestion.Question_Field_Type__c;
@@ -116,7 +115,7 @@ public with sharing class SummitEventsRegisterGuestsController {
                     questionList.add(q);
                 } else {
                     questionData hiddenQuestion = new questionData();
-                    hiddenQuestion.id = seaShared.encryptString(seaQuestion.Id);
+                    hiddenQuestion.id = SummitEventsShared.encryptString(seaQuestion.Id);
                     hiddenQuestion.value = seaQuestion.Default_Value__c;
                     hiddenQuestion.question = seaQuestion.Question_Label__c;
                     hiddenQuestions.add(hiddenQuestion);
@@ -142,7 +141,7 @@ public with sharing class SummitEventsRegisterGuestsController {
                     for (Integer yy = 0; yy < hostedGuests[xx].questions.size(); yy++) {
                         Id questionId = null;
                         try {
-                            questionId = seaShared.decryptString(hostedGuests[xx].questions[yy].id, true);
+                            questionId = SummitEventsShared.decryptString(hostedGuests[xx].questions[yy].id, true);
                         } catch (Exception e) {
                             System.debug(e.getMessage());
                         }
@@ -161,12 +160,12 @@ public with sharing class SummitEventsRegisterGuestsController {
 
             oldRegId = eventRegistration.Id;
             eventRegistration.Id = null;
-            pageFlow = seaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
-            templateSelected = seaShared.getTemplate(eventPage.Template__c);
+            pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
-            eventIsClosed = seaShared.isEventClosed(eventInstance);
+            eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
-            formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
+            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
 
         }
     }
@@ -219,7 +218,7 @@ public with sharing class SummitEventsRegisterGuestsController {
     }
 
     public PageReference checkEventDetails() {
-        return seaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
     public PageReference saveGuests() {
@@ -232,7 +231,7 @@ public with sharing class SummitEventsRegisterGuestsController {
                 for (questionData q : guestAnswers[xx].questions) {
                     Id questionId = null;
                     try {
-                        questionId = seaShared.decryptString(q.id, true);
+                        questionId = SummitEventsShared.decryptString(q.id, true);
                     } catch (Exception e) {
                         System.debug(e.getMessage());
                     }

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -218,7 +218,7 @@ public with sharing class SummitEventsShared {
         }
 
         //check if registration id is there and whether status it is set to registered. IF so reset cookie if it is.
-        if (String.isNotBlank(eventInformation.registrationId)) {
+        if (String.isNotBlank(eventInformation.registrationId) && String.isBlank(eventInformation.valid)) {
             Summit_Events_Registration__c evtReg = new Summit_Events_Registration__c();
             try {
                 evtReg = [
@@ -256,7 +256,7 @@ public with sharing class SummitEventsShared {
 
         Boolean onRegistrationPage = false;
 
-        if (pagename.endsWithIgnoreCase('register')) {
+        if (pageName.endsWithIgnoreCase('register')) {
             onRegistrationPage = true;
         }
 
@@ -275,10 +275,8 @@ public with sharing class SummitEventsShared {
 
         String newRegistrationId = eventInformation.registrationId;
 
-        if (String.isNotBlank(eventInformation.valid) && eventInformation.valid.equalsIgnoreCase('false')) {
+        if (String.isNotBlank(eventInformation.valid) && eventInformation.valid.equalsIgnoreCase('false') && !pageName.equalsIgnoreCase('confirmation')) {
             newRegistrationId = '';
-            //Set on registration to false because we need logic to fire below as if we are not there to reset the registration id
-            onRegistrationPage = false;
         }
 
         if (String.isNotBlank(newInstanceId)) {
@@ -344,13 +342,12 @@ public with sharing class SummitEventsShared {
 
     public static String createEncryptedCookie(String audience, String instanceId, String eventId, String registrationId, Boolean valid) {
         //Check everything to not let nulls through to JSON string
-        System.debug(registrationId);
+        System.debug('Create cookie reg id: '+ registrationId);
         return createEncryptedCookieWithNow(audience, instanceId, eventId, registrationId, Datetime.now(), valid);
     }
 
     public static String createEncryptedCookieWithNow(String audience, String instanceId, String eventId, String registrationId, Datetime nowTime, Boolean valid) {
         //Check everything to not let nulls through to JSON string
-        System.debug(registrationId);
         audience = (String.isNotBlank(audience) && !audience.equalsIgnoreCase('null')) ? audience : '';
         instanceId = (String.isNotBlank(instanceId) && !instanceId.equalsIgnoreCase('null')) ? instanceId : '';
         eventId = (String.isNotBlank(eventId) && !eventId.equalsIgnoreCase('null')) ? eventId : '';

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -5,19 +5,10 @@
 
 public with sharing class SummitEventsShared {
 
-    public class SummitEventsInfo {
-        public String audience { get; set; }
-        public String instanceId { get; set; }
-        public String eventId { get; set; }
-        public String registrationId { get; set; }
-        public String dt { get; set; }
-    }
-
     public SummitEventsShared() {
-
     }
 
-    public String getTemplate(String templateName) {
+    public static String getTemplate(String templateName) {
         List<String> namespaceTemplate = new List<String>{
                 'GeneralSLDS',
                 'crowncollege2020',
@@ -34,7 +25,7 @@ public with sharing class SummitEventsShared {
         return templateName;
     }
 
-    public Map<String, PageReference> getPageFlow(Id eventId, String instanceTitle, PageReference currentPage, Date startDate, Date endDate) {
+    public static Map<String, PageReference> getPageFlow(Id eventId, String instanceTitle, PageReference currentPage, Date startDate, Date endDate) {
 
         //Get the url without anchors
         String currentUrl = currentPage.getUrl();
@@ -184,7 +175,7 @@ public with sharing class SummitEventsShared {
 
     }
 
-    public SummitEventsInfo getSummitEventsInfo() {
+    public static SummitEventsInfo getSummitEventsInfo() {
         //{"audience":"High School Senior","instanceId":"a320m000000A5fOAAS","registrationId":"a350m0000008q63AAA,"eventId":"a330m0000001SOrAAM"}
         SummitEventsInfo eventInformation = new SummitEventsInfo();
         String URLAudience = '';
@@ -259,7 +250,7 @@ public with sharing class SummitEventsShared {
         return eventInformation;
     }
 
-    public PageReference checkForEvent() {
+    public static PageReference checkForEvent() {
         PageReference myVFPage;
         SummitEventsInfo eventInformation = getSummitEventsInfo();
 
@@ -344,12 +335,12 @@ public with sharing class SummitEventsShared {
         return myVFPage;
     }
 
-    public String createEncryptedCookie(String audience, String instanceId, String eventId, String registrationId) {
+    public static String createEncryptedCookie(String audience, String instanceId, String eventId, String registrationId) {
         //Check everything to not let nulls through to JSON string
         return createEncryptedCookieWithNow(audience, instanceId, eventId, registrationId, Datetime.now());
     }
 
-    public String createEncryptedCookieWithNow(String audience, String instanceId, String eventId, String registrationId, Datetime nowTime) {
+    public static String createEncryptedCookieWithNow(String audience, String instanceId, String eventId, String registrationId, Datetime nowTime) {
         //Check everything to not let nulls through to JSON string
         audience = (String.isNotBlank(audience) && !audience.equalsIgnoreCase('null')) ? audience : '';
         instanceId = (String.isNotBlank(instanceId) && !instanceId.equalsIgnoreCase('null')) ? instanceId : '';
@@ -363,7 +354,7 @@ public with sharing class SummitEventsShared {
         return CookieValue;
     }
 
-    public String getDecryptCookie() {
+    public static String getDecryptCookie() {
         String CookieName = 'SummitEvents';
         Cookie encodedCipherText = ApexPages.currentPage().getCookies().get(CookieName);
         if (encodedCipherText != null) {
@@ -372,7 +363,7 @@ public with sharing class SummitEventsShared {
         return '';
     }
 
-    public String encryptString(String toEncrypt) {
+    public static String encryptString(String toEncrypt) {
         String key = getCookieKey();
         String encryptedText = '';
         if (String.isNotBlank(String.valueOf(key))) {
@@ -387,7 +378,7 @@ public with sharing class SummitEventsShared {
         return encryptedText;
     }
 
-    public String decryptString(String encryptedString, Boolean urlDecodeString) {
+    public static String decryptString(String encryptedString, Boolean urlDecodeString) {
         String key = getCookieKey();
         if (String.isNotBlank(encryptedString) && String.isNotBlank(String.valueOf(key))) {
             if (urlDecodeString) {
@@ -407,7 +398,7 @@ public with sharing class SummitEventsShared {
         return '';
     }
 
-    public Boolean isBoolean(String booleanString) {
+    public static Boolean isBoolean(String booleanString) {
         Boolean b;
         booleanString = booleanString.toLowerCase();
         if (booleanString == 'true') {
@@ -422,7 +413,7 @@ public with sharing class SummitEventsShared {
         return b;
     }
 
-    public Boolean isEventClosed(Summit_Events_Instance__c evtInstance) {
+    public static Boolean isEventClosed(Summit_Events_Instance__c evtInstance) {
         // Figure out if the event is closed.
         Boolean eventIsClosed = false;
         if (ApexPages.currentPage() != null && String.isNotBlank(ApexPages.currentPage().getParameters().get('adminopen'))) {
@@ -455,7 +446,7 @@ public with sharing class SummitEventsShared {
         return eventIsClosed;
     }
 
-    public String getTimeZonePick(String pickListTimeZone) {
+    public static String getTimeZonePick(String pickListTimeZone) {
         if (String.isNotBlank(pickListTimeZone)) {
             if (pickListTimeZone.length() > 4) {
                 pickListTimeZone = pickListTimeZone.substring(pickListTimeZone.indexOf('(') + 1, pickListTimeZone.indexOf(')'));
@@ -465,7 +456,7 @@ public with sharing class SummitEventsShared {
         return '';
     }
 
-    public TimeZone getTimeZone(String timeZoneId) {
+    public static TimeZone getTimeZone(String timeZoneId) {
         TimeZone tz = null;
         if (String.isNotBlank(timeZoneId)) {
             tz = TimeZone.getTimeZone(timeZoneId);
@@ -473,7 +464,7 @@ public with sharing class SummitEventsShared {
         return tz;
     }
 
-    public String getTimeZoneDisplay(String timeZonePick, Boolean shortDisplay) {
+    public static String getTimeZoneDisplay(String timeZonePick, Boolean shortDisplay) {
         String displayName = '';
         if (String.isNotBlank(timeZonePick)) {
             timeZonePick = getTimeZonePick(timeZonePick);
@@ -496,7 +487,7 @@ public with sharing class SummitEventsShared {
         return displayName;
     }
 
-    public String navBreadcrumbBuilder(Summit_Events_Instance__c eventInstance) {
+    public static String navBreadcrumbBuilder(Summit_Events_Instance__c eventInstance) {
         String instanceDate = '';
 
         if (eventInstance.Instance_Start_Date__c != null && eventInstance.Instance_End_Date__c != null) {
@@ -560,7 +551,7 @@ public with sharing class SummitEventsShared {
         return instanceDate;
     }
 
-    public Datetime adjustForTimeZone(Datetime dt, String timezoneString) {
+    public static Datetime adjustForTimeZone(Datetime dt, String timezoneString) {
         timezoneString = getTimeZonePick(timezoneString);
         //Get the current GMT time and adjust for our timezone
         //tz = TimeZone.getTimeZone('America/Chicago');
@@ -573,7 +564,7 @@ public with sharing class SummitEventsShared {
         return dt;
     }
 
-    public Datetime convertDateToDatetime(Date dateIn, Time timeIn, String timezoneString) {
+    public static Datetime convertDateToDatetime(Date dateIn, Time timeIn, String timezoneString) {
         if (timeIn == null) {
             timeIn = Time.newInstance(1, 12, 3, 4);
         }
@@ -584,7 +575,7 @@ public with sharing class SummitEventsShared {
         return converted;
     }
 
-    public String formatTime(Time myTime, Boolean military) {
+    public static String formatTime(Time myTime, Boolean military) {
         String formatTime = '';
         if (myTime.hour() >= 13 && myTime.hour() > 0 && !military) {
             formatTime = String.valueOf(myTime.hour() - 12);
@@ -610,7 +601,7 @@ public with sharing class SummitEventsShared {
         return formatTime;
     }
 
-    public String removeHTMLandEscape(String incomingString, Boolean escapeHTML) {
+    public static String removeHTMLandEscape(String incomingString, Boolean escapeHTML) {
         if (String.isNotBlank(incomingString)) {
             incomingString = incomingString.replaceAll('<[^>]+>', '').trim();
             if (escapeHTML) {
@@ -621,7 +612,7 @@ public with sharing class SummitEventsShared {
     }
 
     //Method to test object and field availability for current user (Guest user)
-    public String checkFieldGuestAccess(String objectApiName, String fieldName, String requiredFieldType, Boolean testCreatable, String qualifierLabel) {
+    public static String checkFieldGuestAccess(String objectApiName, String fieldName, String requiredFieldType, Boolean testCreatable, String qualifierLabel) {
         String returnError = '';
         DescribeFieldResult fieldDescribe;
         SObjectType schemaType;
@@ -666,7 +657,7 @@ public with sharing class SummitEventsShared {
         return returnError;
     }
 
-    public Map<String, String> getDependentSelectOptions(String parentObjName, String parentFieldName, String dependentFieldName, String parentValue) {
+    public static Map<String, String> getDependentSelectOptions(String parentObjName, String parentFieldName, String dependentFieldName, String parentValue) {
         Map<String, String> dependentItems = new Map<String, String>();
         if (null != parentObjName && null != parentFieldName && null != dependentFieldName && null != parentValue) {
             String namespace = SummitEventsNamespace.getNamespace();
@@ -737,7 +728,7 @@ public with sharing class SummitEventsShared {
         return retVal;
     }
 
-    public String getCookieKey() {
+    public static String getCookieKey() {
         String key = '';
         Summit_Events_Settings__c SummitEventsSettings = Summit_Events_Settings__c.getOrgDefaults();
         if (String.isNotBlank(SummitEventsSettings.Cookie_Encryption_Key__c)) {

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -176,7 +176,7 @@ public with sharing class SummitEventsShared {
     }
 
     public static SummitEventsInfo getSummitEventsInfo() {
-        //{"audience":"High School Senior","instanceId":"a320m000000A5fOAAS","registrationId":"a350m0000008q63AAA,"eventId":"a330m0000001SOrAAM"}
+        //{"audience":"High School Senior","instanceId":"a320m000000A5fOAAS","registrationId":"a350m0000008q63AAA,"eventId":"a330m0000001SOrAAM","valid":"true"}
         SummitEventsInfo eventInformation = new SummitEventsInfo();
         String URLAudience = '';
         if (String.isNotBlank(ApexPages.currentPage().getParameters().get('audience'))) {
@@ -250,13 +250,13 @@ public with sharing class SummitEventsShared {
         return eventInformation;
     }
 
-    public static PageReference checkForEvent() {
+    public static PageReference checkForEvent(String pageName) {
         PageReference myVFPage;
         SummitEventsInfo eventInformation = getSummitEventsInfo();
 
         Boolean onRegistrationPage = false;
-        String[] currentURL = ApexPages.currentPage().getUrl().split('\\?');
-        if (currentURL[0].endsWithIgnoreCase('SummitEventsRegister')) {
+
+        if (pagename.endsWithIgnoreCase('register')) {
             onRegistrationPage = true;
         }
 
@@ -274,6 +274,13 @@ public with sharing class SummitEventsShared {
         }
 
         String newRegistrationId = eventInformation.registrationId;
+
+        if (String.isNotBlank(eventInformation.valid) && eventInformation.valid.equalsIgnoreCase('false')) {
+            newRegistrationId = '';
+            //Set on registration to false because we need logic to fire below as if we are not there to reset the registration id
+            onRegistrationPage = false;
+        }
+
         if (String.isNotBlank(newInstanceId)) {
             Summit_Events_Instance__c eventPage = [
                     SELECT Event__r.Event_Home_Link_URL__c
@@ -327,26 +334,29 @@ public with sharing class SummitEventsShared {
             myVFPage = new PageReference(newUrl);
             myVFPage.setRedirect(true);
             newRegistrationId = '';
-            createEncryptedCookie(eventInformation.audience, newInstanceId, eventInformation.eventId, newRegistrationId);
+            createEncryptedCookie(eventInformation.audience, newInstanceId, eventInformation.eventId, newRegistrationId, true);
         } else if (onRegistrationPage) {
-            createEncryptedCookie(eventInformation.audience, newInstanceId, eventInformation.eventId, newRegistrationId);
+            createEncryptedCookie(eventInformation.audience, newInstanceId, eventInformation.eventId, newRegistrationId, true);
         }
 
         return myVFPage;
     }
 
-    public static String createEncryptedCookie(String audience, String instanceId, String eventId, String registrationId) {
+    public static String createEncryptedCookie(String audience, String instanceId, String eventId, String registrationId, Boolean valid) {
         //Check everything to not let nulls through to JSON string
-        return createEncryptedCookieWithNow(audience, instanceId, eventId, registrationId, Datetime.now());
+        System.debug(registrationId);
+        return createEncryptedCookieWithNow(audience, instanceId, eventId, registrationId, Datetime.now(), valid);
     }
 
-    public static String createEncryptedCookieWithNow(String audience, String instanceId, String eventId, String registrationId, Datetime nowTime) {
+    public static String createEncryptedCookieWithNow(String audience, String instanceId, String eventId, String registrationId, Datetime nowTime, Boolean valid) {
         //Check everything to not let nulls through to JSON string
+        System.debug(registrationId);
         audience = (String.isNotBlank(audience) && !audience.equalsIgnoreCase('null')) ? audience : '';
         instanceId = (String.isNotBlank(instanceId) && !instanceId.equalsIgnoreCase('null')) ? instanceId : '';
         eventId = (String.isNotBlank(eventId) && !eventId.equalsIgnoreCase('null')) ? eventId : '';
         registrationId = (String.isNotBlank(registrationId) && !registrationId.equalsIgnoreCase('null')) ? registrationId : '';
-        String CookieValue = encryptString('{"audience":"' + audience + '","instanceId":"' + instanceId + '","eventId":"' + eventId + '","registrationId":"' + registrationId + '","dt":"' + String.valueOf(nowTime) + '"}');
+        valid = (valid != null) ? valid : false;
+        String CookieValue = encryptString('{"audience":"' + audience + '","instanceId":"' + instanceId + '","eventId":"' + eventId + '","registrationId":"' + registrationId + '","dt":"' + String.valueOf(nowTime) + '","valid":"' + String.valueOf(valid) + '"}');
         Cookie SummitEventsCookie = new Cookie('SummitEvents', CookieValue, null, -1, true, 'Strict');
         ApexPages.currentPage().setCookies(new Cookie[]{
                 SummitEventsCookie
@@ -619,7 +629,7 @@ public with sharing class SummitEventsShared {
         splitList.addAll(sanitizePicklistString(returnSepStringList2));
         for (String p : splitList) {
             p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
-            if(String.isNotBlank(p)) {
+            if (String.isNotBlank(p)) {
                 cpl.add(new SelectOption(p, p));
             }
         }

--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -611,6 +611,31 @@ public with sharing class SummitEventsShared {
         return incomingString;
     }
 
+    public static List<SelectOption> createPicklistsFromStrings(String returnSepStringList, String returnSepStringList2) {
+        List<SelectOption> cpl = new List<SelectOption>();
+        cpl.add(new SelectOption('', 'Select...'));
+        List<String> splitList = new List<String>();
+        splitList.addAll(sanitizePicklistString(returnSepStringList));
+        splitList.addAll(sanitizePicklistString(returnSepStringList2));
+        for (String p : splitList) {
+            p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
+            if(String.isNotBlank(p)) {
+                cpl.add(new SelectOption(p, p));
+            }
+        }
+        return cpl;
+    }
+
+    public static List<String> sanitizePicklistString(String picklistString) {
+        List<String> pickList = new List<String>();
+        if (String.isNotBlank(picklistString)) {
+            picklistString = picklistString.trim();
+            picklistString = picklistString.replace('\n\n', '\n');
+            pickList = picklistString.split('\n');
+        }
+        return pickList;
+    }
+
     //Method to test object and field availability for current user (Guest user)
     public static String checkFieldGuestAccess(String objectApiName, String fieldName, String requiredFieldType, Boolean testCreatable, String qualifierLabel) {
         String returnError = '';

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -4,8 +4,7 @@
 // Created by Thaddaeus Dahlberg on 5/1/2018.
 
 public with sharing class SummitEventsSubmitController {
-    public SummitEventsShared seaShared = new SummitEventsShared();
-    public SummitEventsShared.SummitEventsInfo eventInformation { get; set; }
+    public SummitEventsInfo eventInformation { get; set; }
     public Summit_Events__c eventPage { get; set; }
     public Summit_Events_Instance__c eventInstance { get; set; }
     public List<Summit_Events_Appointment_Type__c> appointments { get; set; }
@@ -40,7 +39,7 @@ public with sharing class SummitEventsSubmitController {
         hasMessages = false;
 
         //Get cookie or URL string variable
-        eventInformation = seaShared.getSummitEventsInfo();
+        eventInformation = SummitEventsShared.getSummitEventsInfo();
 
         if (!String.isEmpty(eventInformation.eventId)) {
             eventPage = [
@@ -54,7 +53,7 @@ public with sharing class SummitEventsSubmitController {
                     WITH SECURITY_ENFORCED
             ];
 
-            templateSelected = seaShared.getTemplate(eventPage.Template__c);
+            templateSelected = SummitEventsShared.getTemplate(eventPage.Template__c);
 
             if (String.isNotBlank(eventPage.Payment_Gateway__c) && eventPage.Payment_Gateway__c != 'No Gateway') {
                 hasPaymentGateway = true;
@@ -70,15 +69,15 @@ public with sharing class SummitEventsSubmitController {
                     WITH SECURITY_ENFORCED
             ];
 
-            pageFlow = seaShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
+            pageFlow = SummitEventsShared.getPageFlow(eventInformation.eventId, eventInstance.Instance_Title__c, ApexPages.currentPage(), eventInstance.Instance_Start_Date__c, eventInstance.Instance_End_Date__c);
 
-            eventIsClosed = seaShared.isEventClosed(eventInstance);
+            eventIsClosed = SummitEventsShared.isEventClosed(eventInstance);
 
             if (String.isNotBlank(ApexPages.currentPage().getParameters().get('error'))) {
                 ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.WARNING, ApexPages.currentPage().getParameters().get('error')));
             }
 
-            formattedNavDate = seaShared.navBreadcrumbBuilder(eventInstance);
+            formattedNavDate = SummitEventsShared.navBreadcrumbBuilder(eventInstance);
         }
 
         if (!String.isBlank(eventInformation.registrationId)) {
@@ -110,7 +109,7 @@ public with sharing class SummitEventsSubmitController {
                     for (Integer yy = 0; yy < guestAnswers[xx].questions.size(); yy++) {
                         Id questionId = null;
                         try {
-                            questionId = seaShared.decryptString(guestAnswers[xx].questions[yy].id, true);
+                            questionId = SummitEventsShared.decryptString(guestAnswers[xx].questions[yy].id, true);
                         } catch (Exception e) {
                             System.debug(e.getMessage());
                         }
@@ -138,7 +137,7 @@ public with sharing class SummitEventsSubmitController {
             ];
 
             for(Integer x = 0; x < chosenAppointments.size(); x++) {
-                chosenAppointments[x].Description__c = seaShared.removeHTMLandEscape(chosenAppointments[x].Description__c, false);
+                chosenAppointments[x].Description__c = SummitEventsShared.removeHTMLandEscape(chosenAppointments[x].Description__c, false);
             }
 
             /** Check for preexisting payment **/
@@ -189,7 +188,7 @@ public with sharing class SummitEventsSubmitController {
     }
 
     public PageReference checkEventDetails() {
-        return seaShared.checkForEvent();
+        return SummitEventsShared.checkForEvent();
     }
 
     public PageReference submitRegistration() {

--- a/force-app/main/default/classes/SummitEventsSubmitController.cls
+++ b/force-app/main/default/classes/SummitEventsSubmitController.cls
@@ -20,7 +20,6 @@ public with sharing class SummitEventsSubmitController {
     public List<questionGuestData> guestAnswers { get; set; }
     public Map<String, PageReference> pageFlow { get; set; }
     public Boolean hasPaymentGateway { get; set; }
-    public Boolean hasFees { get; set; }
     public Boolean hasMessages { get; set; }
 
     public class questionGuestData {
@@ -35,7 +34,6 @@ public with sharing class SummitEventsSubmitController {
     }
 
     public SummitEventsSubmitController() {
-        hasFees = false;
         hasMessages = false;
 
         //Get cookie or URL string variable
@@ -176,9 +174,6 @@ public with sharing class SummitEventsSubmitController {
                     totalPaymentAmount = totalPaymentAmount - existingPaymentAmount;
                 }
             }
-            if (totalPaymentAmount > 0) {
-                hasFees = true;
-            }
         }
         ApexPages.Message[] pageMessages = ApexPages.getMessages();
         if (pageMessages.size() > 0) {
@@ -188,7 +183,7 @@ public with sharing class SummitEventsSubmitController {
     }
 
     public PageReference checkEventDetails() {
-        return SummitEventsShared.checkForEvent();
+        return SummitEventsShared.checkForEvent('submit');
     }
 
     public PageReference submitRegistration() {

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -1829,6 +1829,36 @@
                 <identifier>record_item_086</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Guest_Unsaved_Modal_Text__c</fieldItem>
+                <identifier>RecordGuest_Unsaved_Modal_Text_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Guest_Unsaved_Cancel_Label__c</fieldItem>
+                <identifier>RecordGuest_Unsaved_Cancel_Label_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Guest_Unsaved_Continue_Label__c</fieldItem>
+                <identifier>RecordGuest_Unsaved_Continue_Label_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-6f1934ef-fd4d-4e34-a85f-55d2a419f40b</name>
         <type>Facet</type>
     </flexiPageRegions>

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -2611,8 +2611,8 @@
                     <name>uiBehavior</name>
                     <value>none</value>
                 </fieldInstanceProperties>
-                <fieldItem>Record.Event_Fee_Submit_List_Label__c</fieldItem>
-                <identifier>record_item_116</identifier>
+                <fieldItem>Record.Event_Fees_Received_Label__c</fieldItem>
+                <identifier>RecordEvent_Fees_Received_Label_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-898af6dc-1c84-435e-be26-075f1ef026e6</name>
@@ -2627,6 +2627,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Event_Fee_Total_Label__c</fieldItem>
                 <identifier>record_item_117</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Fee_Submit_List_Label__c</fieldItem>
+                <identifier>record_item_116</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-59d9f745-618f-4d64-bc94-e4bc5cf26806</name>

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -1369,10 +1369,6 @@
                 <identifier>record_item_075</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-49c2a790-1cbe-40c2-9641-a7ea496a54a4</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1383,6 +1379,10 @@
                 <identifier>record_item_076</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-49c2a790-1cbe-40c2-9641-a7ea496a54a4</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1391,6 +1391,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Add_Info_Question_Pick_List_4__c</fieldItem>
                 <identifier>record_item_077</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Add_Info_Question_Pick_List_Long_4__c</fieldItem>
+                <identifier>RecordAdd_Info_Question_Pick_List_Long_4_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-4353a557-f62b-4122-82be-c765aed4626f</name>

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -2615,6 +2615,26 @@
                 <identifier>RecordEvent_Fees_Received_Label_cField</identifier>
             </fieldInstance>
         </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Payment_Due_Heading_Label__c</fieldItem>
+                <identifier>RecordEvent_Payment_Due_Heading_Label_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Payment_Due_Description__c</fieldItem>
+                <identifier>RecordEvent_Payment_Due_Description_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
         <name>Facet-898af6dc-1c84-435e-be26-075f1ef026e6</name>
         <type>Facet</type>
     </flexiPageRegions>
@@ -2637,6 +2657,26 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Event_Fee_Submit_List_Label__c</fieldItem>
                 <identifier>record_item_116</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Payment_Received_Heading_Label__c</fieldItem>
+                <identifier>RecordEvent_Payment_Received_Heading_Label_cField</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Event_Payment_Received_Description__c</fieldItem>
+                <identifier>RecordEvent_Payment_Received_Description_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-59d9f745-618f-4d64-bc94-e4bc5cf26806</name>

--- a/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/Summit_Events_Record_Page.flexipage-meta.xml
@@ -1153,10 +1153,6 @@
                 <identifier>record_item_066</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-8c228279-6d57-4f6d-b714-7f39947ba3cd</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1167,6 +1163,10 @@
                 <identifier>record_item_067</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-8c228279-6d57-4f6d-b714-7f39947ba3cd</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1175,6 +1175,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Add_Info_Question_Pick_List_1__c</fieldItem>
                 <identifier>record_item_068</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Add_Info_Question_Pick_List_Long_1__c</fieldItem>
+                <identifier>RecordAdd_Info_Question_Pick_List_Long_1_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-6e08869c-a7a8-4509-b6f2-254b33861288</name>
@@ -1215,10 +1225,6 @@
                 <identifier>record_item_069</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-4dc8f791-8dd3-43f0-b35a-3ba0ac90ebc1</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1229,6 +1235,10 @@
                 <identifier>record_item_070</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-4dc8f791-8dd3-43f0-b35a-3ba0ac90ebc1</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1237,6 +1247,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Add_Info_Question_Pick_List_2__c</fieldItem>
                 <identifier>record_item_071</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Add_Info_Question_Pick_List_Long_2__c</fieldItem>
+                <identifier>RecordAdd_Info_Question_Pick_List_Long_2_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-3fe9b7ac-d949-4b97-8972-ebb2c952a639</name>
@@ -1277,10 +1297,6 @@
                 <identifier>record_item_072</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-56e813b7-d6f5-46a3-82f7-18115abdfe56</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1291,6 +1307,10 @@
                 <identifier>record_item_073</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-56e813b7-d6f5-46a3-82f7-18115abdfe56</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1299,6 +1319,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Add_Info_Question_Pick_List_3__c</fieldItem>
                 <identifier>record_item_074</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Add_Info_Question_Pick_List_Long_3__c</fieldItem>
+                <identifier>RecordAdd_Info_Question_Pick_List_Long_3_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-484c67ff-4026-4690-bef9-3d3344dde4b7</name>
@@ -1401,10 +1431,6 @@
                 <identifier>record_item_078</identifier>
             </fieldInstance>
         </itemInstances>
-        <name>Facet-93769726-74b5-4863-9e99-76ca7f60275c</name>
-        <type>Facet</type>
-    </flexiPageRegions>
-    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1415,6 +1441,10 @@
                 <identifier>record_item_079</identifier>
             </fieldInstance>
         </itemInstances>
+        <name>Facet-93769726-74b5-4863-9e99-76ca7f60275c</name>
+        <type>Facet</type>
+    </flexiPageRegions>
+    <flexiPageRegions>
         <itemInstances>
             <fieldInstance>
                 <fieldInstanceProperties>
@@ -1423,6 +1453,16 @@
                 </fieldInstanceProperties>
                 <fieldItem>Record.Add_Info_Question_Pick_List_5__c</fieldItem>
                 <identifier>record_item_080</identifier>
+            </fieldInstance>
+        </itemInstances>
+        <itemInstances>
+            <fieldInstance>
+                <fieldInstanceProperties>
+                    <name>uiBehavior</name>
+                    <value>none</value>
+                </fieldInstanceProperties>
+                <fieldItem>Record.Add_Info_Question_Pick_List_Long_5__c</fieldItem>
+                <identifier>RecordAdd_Info_Question_Pick_List_Long_5_cField</identifier>
             </fieldInstance>
         </itemInstances>
         <name>Facet-c0199129-1f50-4096-9aba-3b4b5052ba8b</name>

--- a/force-app/main/default/layouts/Summit_Events_Question__c-Summit Events Question Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events_Question__c-Summit Events Question Layout.layout-meta.xml
@@ -93,6 +93,10 @@
                 <behavior>Edit</behavior>
                 <field>Picklist_Values__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Picklist_Values_Long__c</field>
+            </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
     </layoutSections>
@@ -197,7 +201,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h7g000003dRZD</masterLabel>
+        <masterLabel>00h8N000003Fl2n</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -145,6 +145,10 @@
                 <behavior>Edit</behavior>
                 <field>Event_Fee_Allocation__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Fees_Received_Label__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -839,7 +843,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8N000003Fl2p</masterLabel>
+        <masterLabel>00hDS00000BYONh</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -252,6 +252,14 @@
                 <behavior>Edit</behavior>
                 <field>No_Guest_Registrations_Added_Message__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Guest_Submit_List_Label__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Guest_Unsaved_Continue_Label__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -269,6 +277,14 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Guest_Registration_Description__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Guest_Unsaved_Cancel_Label__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Guest_Unsaved_Modal_Text__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsTopToBottom</style>

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -149,6 +149,14 @@
                 <behavior>Edit</behavior>
                 <field>Event_Fees_Received_Label__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Payment_Button_Label__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Payment_Gateway__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -158,6 +166,22 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Event_Fee_Additional_Allocation__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Payment_Due_Description__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Payment_Due_Heading_Label__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Payment_Received_Heading_Label__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Event_Payment_Received_Description__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -843,7 +867,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00hDS00000BYONh</masterLabel>
+        <masterLabel>00h8B000001VR0Q</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Summit_Events__c-Summit Event Default Layout.layout-meta.xml
@@ -379,6 +379,10 @@
                 <field>Add_Info_Question_Pick_List_1__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Add_Info_Question_Pick_List_Long_1__c</field>
+            </layoutItems>
+            <layoutItems>
                 <emptySpace>true</emptySpace>
             </layoutItems>
             <layoutItems>
@@ -392,6 +396,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Add_Info_Question_Pick_List_2__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Add_Info_Question_Pick_List_Long_2__c</field>
             </layoutItems>
             <layoutItems>
                 <emptySpace>true</emptySpace>
@@ -408,6 +416,10 @@
                 <behavior>Edit</behavior>
                 <field>Add_Info_Question_Pick_List_3__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Add_Info_Question_Pick_List_Long_3__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>
@@ -423,6 +435,10 @@
                 <field>Add_Info_Question_Pick_List_4__c</field>
             </layoutItems>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Add_Info_Question_Pick_List_Long_4__c</field>
+            </layoutItems>
+            <layoutItems>
                 <emptySpace>true</emptySpace>
             </layoutItems>
             <layoutItems>
@@ -436,6 +452,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>Add_Info_Question_Pick_List_5__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Add_Info_Question_Pick_List_Long_5__c</field>
             </layoutItems>
         </layoutColumns>
         <style>TwoColumnsLeftToRight</style>
@@ -803,7 +823,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h8B000001auye</masterLabel>
+        <masterLabel>00h8N000003Fl2p</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/objects/Summit_Events_Question__c/fields/Picklist_Values_Long__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Question__c/fields/Picklist_Values_Long__c.field-meta.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Picklist_Values_Long__c</fullName>
+    <description>This field enables user to create Picklist values for a Picklist question, return/line separated.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This field enables user to create Picklist values for a Picklist question, return/line separated.</inlineHelpText>
+    <label>Picklist Values</label>
+    <length>32000</length>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events_Question__c/fields/Picklist_Values_Long__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Question__c/fields/Picklist_Values_Long__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>This field enables user to create Picklist values for a Picklist question, return/line separated.</description>
     <externalId>false</externalId>
     <inlineHelpText>This field enables user to create Picklist values for a Picklist question, return/line separated.</inlineHelpText>
-    <label>Picklist Values</label>
+    <label>Picklist Values Long</label>
     <length>32000</length>
     <trackTrending>false</trackTrending>
     <type>LongTextArea</type>

--- a/force-app/main/default/objects/Summit_Events_Question__c/validationRules/All_Picklist_fields_require_values.validationRule-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Question__c/validationRules/All_Picklist_fields_require_values.validationRule-meta.xml
@@ -4,6 +4,6 @@
     <active>true</active>
     <errorConditionFormula>ISPICKVAL(Question_Field_Type__c, &apos;Picklist&apos;) &amp;&amp; 
 
-ISPICKVAL(Existing_Picklist_Values__c, &quot;&quot;) = ISBLANK(Picklist_Values__c)</errorConditionFormula>
+ISPICKVAL(Existing_Picklist_Values__c, &quot;&quot;) = ISBLANK(Picklist_Values__c + Picklist_Values_Long__c)</errorConditionFormula>
     <errorMessage>When Question Type = Picklist, one of the Picklist Type fields must have a value for record to be saved.</errorMessage>
 </ValidationRule>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Instance_End_Time_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Instance_End_Time_Text__c.field-meta.xml
@@ -10,7 +10,7 @@ IF( MINUTE(Event_Instance_End_Time__c)  &lt; 10 , &quot;0&quot; &amp; TEXT( MINU
 &amp;
 &quot; &quot;
 &amp;
-IF( HOUR(Event_Instance_End_Time__c) &gt;= 13, &quot;PM&quot;, &quot;AM&quot;)</formula>
+IF( HOUR(Event_Instance_End_Time__c) &gt;= 12, &quot;PM&quot;, &quot;AM&quot;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Event Instance End Time Text</label>
     <required>false</required>

--- a/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Instance_Start_Time_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events_Registration__c/fields/Event_Instance_Start_Time_Text__c.field-meta.xml
@@ -6,11 +6,11 @@
 &amp;
 &quot;:&quot;
 &amp;
-IF( MINUTE(Event_Instance_Start_Time__c)  &lt; 10 , &quot;0&quot; &amp; TEXT( MINUTE(Event_Instance_Start_Time__c)), TEXT(MINUTE(Event_Instance_Start_Time__c)))
+IF( MINUTE(Event_Instance_Start_Time__c) &lt; 10 , &quot;0&quot; &amp; TEXT( MINUTE(Event_Instance_Start_Time__c)), TEXT(MINUTE(Event_Instance_Start_Time__c)))
 &amp;
 &quot; &quot;
 &amp;
-IF( HOUR(Event_Instance_Start_Time__c) &gt;= 13, &quot;PM&quot;, &quot;AM&quot;)</formula>
+IF( HOUR(Event_Instance_Start_Time__c) &gt;= 12, &quot;PM&quot;, &quot;AM&quot;)</formula>
     <formulaTreatBlanksAs>BlankAsZero</formulaTreatBlanksAs>
     <label>Event Instance Start Time Text</label>
     <required>false</required>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_1__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_1__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Add_Info_Question_Pick_List_1__c</fullName>
-    <description>return separated list that will be converted to a pick-list.</description>
+    <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
-    <inlineHelpText>return separated list that will be converted to a pick-list.</inlineHelpText>
+    <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
     <label>Add Info Question Pick List 1</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_2__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_2__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Add_Info_Question_Pick_List_2__c</fullName>
-    <description>return separated list that will be converted to a pick-list.</description>
+    <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
-    <inlineHelpText>return separated list that will be converted to a pick-list.</inlineHelpText>
+    <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
     <label>Add Info Question Pick List 2</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_3__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_3__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Add_Info_Question_Pick_List_3__c</fullName>
-    <description>return separated list that will be converted to a pick-list.</description>
+    <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
-    <inlineHelpText>return separated list that will be converted to a pick-list.</inlineHelpText>
+    <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
     <label>Add Info Question Pick List 3</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_4__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_4__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Add_Info_Question_Pick_List_4__c</fullName>
-    <description>return separated list that will be converted to a pick-list.</description>
+    <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
-    <inlineHelpText>return separated list that will be converted to a pick-list.</inlineHelpText>
+    <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
     <label>Add Info Question Pick List 4</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_1__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_1__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Add_Info_Question_Pick_List_5__c</fullName>
+    <fullName>Add_Info_Question_Pick_List_Long_1__c</fullName>
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 5</label>
-    <required>false</required>
+    <label>Add Info Question Pick List 1</label>
+    <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>TextArea</type>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_1__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_1__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 1</label>
+    <label>Add Info Question Pick List Long 1</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Add_Info_Question_Pick_List_5__c</fullName>
+    <fullName>Add_Info_Question_Pick_List_Long_2__c</fullName>
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 5</label>
-    <required>false</required>
+    <label>Add Info Question Pick List 1</label>
+    <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>TextArea</type>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List Long 1</label>
+    <label>Add Info Question Pick List Long 2</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_2__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 1</label>
+    <label>Add Info Question Pick List Long 1</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List Long 1</label>
+    <label>Add Info Question Pick List Long 3</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Add_Info_Question_Pick_List_5__c</fullName>
+    <fullName>Add_Info_Question_Pick_List_Long_3__c</fullName>
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 5</label>
-    <required>false</required>
+    <label>Add Info Question Pick List 1</label>
+    <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>TextArea</type>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_3__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 1</label>
+    <label>Add Info Question Pick List Long 1</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Add_Info_Question_Pick_List_5__c</fullName>
+    <fullName>Add_Info_Question_Pick_List_Long_4__c</fullName>
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 5</label>
-    <required>false</required>
+    <label>Add Info Question Pick List 1</label>
+    <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>TextArea</type>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List Long 1</label>
+    <label>Add Info Question Pick List Long 4</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_4__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 1</label>
+    <label>Add Info Question Pick List Long 1</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
-    <fullName>Add_Info_Question_Pick_List_5__c</fullName>
+    <fullName>Add_Info_Question_Pick_List_Long_5__c</fullName>
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 5</label>
-    <required>false</required>
+    <label>Add Info Question Pick List 1</label>
+    <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>
-    <type>TextArea</type>
+    <type>LongTextArea</type>
+    <visibleLines>5</visibleLines>
 </CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List Long 1</label>
+    <label>Add Info Question Pick List Long 5</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Add_Info_Question_Pick_List_Long_5__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>Return separated list that will be converted to a pick-list.</description>
     <externalId>false</externalId>
     <inlineHelpText>Return separated list that will be converted to a pick-list.</inlineHelpText>
-    <label>Add Info Question Pick List 1</label>
+    <label>Add Info Question Pick List Long 1</label>
     <length>10000</length>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Label__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Fee_Label__c</fullName>
+    <defaultValue>&quot;Event Cost&quot;</defaultValue>
     <description>The label you wish to apply to the cost of the event itself. This will default to &quot;Event Cost.&quot;</description>
     <externalId>false</externalId>
     <inlineHelpText>The label you wish to apply to the cost of the event itself. This will default to &quot;Event Cost.&quot;</inlineHelpText>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Submit_List_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Submit_List_Label__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Fee_Submit_List_Label__c</fullName>
+    <defaultValue>&quot;Event Charges&quot;</defaultValue>
     <description>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Event Charges&quot;</description>
     <externalId>false</externalId>
     <inlineHelpText>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Event Charges&quot;</inlineHelpText>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Total_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Fee_Total_Label__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Fee_Total_Label__c</fullName>
+    <defaultValue>&quot;Total&quot;</defaultValue>
     <description>Appears on the total cost line of the submit page fee listing. Defaults to &quot;Total&quot;</description>
     <externalId>false</externalId>
     <inlineHelpText>Appears on the total cost line of the submit page fee listing. Defaults to &quot;Total&quot;</inlineHelpText>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Fees_Received_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Fees_Received_Label__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Fees_Received_Label__c</fullName>
+    <defaultValue>&quot;Payments Received&quot;</defaultValue>
     <description>Appears on the confirmation page as title to the itemized list of fees where fee received is displayed. Defaults to &quot;Payments Received&quot;</description>
     <externalId>false</externalId>
     <inlineHelpText>Appears on the confirmation page as title to the itemized list of fees where fee received is displayed. Defaults to &quot;Payments Received&quot;</inlineHelpText>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Fees_Received_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Fees_Received_Label__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Fees_Received_Label__c</fullName>
+    <description>Appears on the confirmation page as title to the itemized list of fees where fee received is displayed. Defaults to &quot;Payments Received&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>Appears on the confirmation page as title to the itemized list of fees where fee received is displayed. Defaults to &quot;Payments Received&quot;</inlineHelpText>
+    <label>Event Fees Received Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Due_Description__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Due_Description__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Payment_Due_Description__c</fullName>
+    <description>This is an optional opportunity to add more description when a payment is received. It appears after the Payment Received heading.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This is an optional opportunity to add more description when a payment is received. It appears after the Payment Received heading.</inlineHelpText>
+    <label>Event Payment Due Description</label>
+    <length>32768</length>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Html</type>
+    <visibleLines>25</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Due_Heading_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Due_Heading_Label__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Payment_Due_Heading_Label__c</fullName>
+    <defaultValue>&quot;Payment Due&quot;</defaultValue>
+    <description>The heading that appear above the fees when payment was not received and fees are still due. Defaults to &quot;Payment Due.&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The heading that appear above the fees when payment was not received and fees are still due. Defaults to &quot;Payment Due.&quot;</inlineHelpText>
+    <label>Event Payment Due Heading Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Received_Description__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Received_Description__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Payment_Received_Description__c</fullName>
+    <description>This is an optional opportunity to add more description when a payment was not received and fees are still due. It appears after the Payment Due heading and before the fee list.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This is an optional opportunity to add more description when a payment was not received and fees are still due. It appears after the Payment Due heading and before the fee list.</inlineHelpText>
+    <label>Event Payment Received Description</label>
+    <length>32768</length>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Html</type>
+    <visibleLines>25</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Received_Heading_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Payment_Received_Heading_Label__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Event_Payment_Received_Heading_Label__c</fullName>
+    <defaultValue>&quot;Payment Received&quot;</defaultValue>
+    <description>The heading that appear above the fees when all payments are received. Defaults to &quot;Payment Received.&quot;</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The heading that appear above the fees when all payments are received. Defaults to &quot;Payment Received.&quot;</inlineHelpText>
+    <label>Event Payment Received Heading Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Feed_Registration_Button_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Feed_Registration_Button_Text__c.field-meta.xml
@@ -2,9 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Feed_Registration_Button_Text__c</fullName>
     <defaultValue>&quot;Register&quot;</defaultValue>
-    <description>The text of the registration link in the feeds that appear on external Web sites. Will default to &quot;Register&quot; i not defined.</description>
+    <description>The text of the registration link in the feeds that appear on external Web sites. Will default to &quot;Register&quot; if not defined.</description>
     <externalId>false</externalId>
-    <inlineHelpText>The text of the registration link in the feeds that appear on external Web sites. Will default to &quot;Register&quot; i not defined.</inlineHelpText>
+    <inlineHelpText>The text of the registration link in the feeds that appear on external Web sites. Will default to &quot;Register&quot; if not defined.</inlineHelpText>
     <label>Feed Registration Button Text</label>
     <length>255</length>
     <required>false</required>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Cancel_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Cancel_Label__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Guest_Unsaved_Cancel_Label__c</fullName>
+    <defaultValue>&quot;Cancel&quot;</defaultValue>
+    <description>The label of the cancel button on the dialog that pops up when unsaved guest data is present.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The label of the cancel button on the dialog that pops up when unsaved guest data is present.</inlineHelpText>
+    <label>Guest Unsaved Cancel Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Continue_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Continue_Label__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Guest_Unsaved_Continue_Label__c</fullName>
+    <defaultValue>&quot;Continue&quot;</defaultValue>
+    <description>TThe label of the continue button on the dialog that pops up when unsaved guest data is present.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>The label of the continue button on the dialog that pops up when unsaved guest data is present.</inlineHelpText>
+    <label>Guest Unsaved Continue Label</label>
+    <length>255</length>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Modal_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Modal_Text__c.field-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Guest_Unsaved_Modal_Text__c</fullName>
-    <defaultValue>&quot;You have unsaved guest information entered. Do you wish to continue without saving?&quot;</defaultValue>
+    <defaultValue>&quot;You have unsaved Guest information entered. Select Cancel to finish adding your guests.&quot;</defaultValue>
     <description>This text appears in the dialog that pops up if unsaved guest information is present.</description>
     <externalId>false</externalId>
     <inlineHelpText>This text appears in the dialog that pops up if unsaved guest information is present.</inlineHelpText>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Modal_Text__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Guest_Unsaved_Modal_Text__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Guest_Unsaved_Modal_Text__c</fullName>
+    <defaultValue>&quot;You have unsaved guest information entered. Do you wish to continue without saving?&quot;</defaultValue>
+    <description>This text appears in the dialog that pops up if unsaved guest information is present.</description>
+    <externalId>false</externalId>
+    <inlineHelpText>This text appears in the dialog that pops up if unsaved guest information is present.</inlineHelpText>
+    <label>Guest Unsaved Modal Text</label>
+    <length>2000</length>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/force-app/main/default/objects/Summit_Events__c/fields/Payment_Button_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Payment_Button_Label__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Payment_Button_Label__c</fullName>
+    <defaultValue>&quot;Make Payment&quot;</defaultValue>
     <description>If a gateway is defined and there are fees for the event the submit page will show a payment button. This label allows you to adjust its messaging. Default is &quot;Make Payment.&quot;</description>
     <externalId>false</externalId>
     <inlineHelpText>If a gateway is defined and there are fees for the event the submit page will show a payment button. This label allows you to adjust its messaging. Default is &quot;Make Payment.&quot;</inlineHelpText>

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -116,6 +116,16 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                         </apex:outputText>
                                     </td>
                                 </tr>
+                                <apex:outputPanel layout="none" rendered="{!!ISBLANK(existingPaymentAmount)}">
+                                    <tr class="eventOnlyCost">
+                                        <td>{!IF(ISBLANK(eventPage.Event_Fees_Received_Label__c),'Payment Recieved', eventPage.Event_Fees_Received_Label__c)}</td>
+                                        <td class="slds-text-align_right">
+                                            <apex:outputText value="${0,number,###,###,###,##0.00}">
+                                                <apex:param value="{!existingPaymentAmount}"/>
+                                            </apex:outputText>
+                                        </td>
+                                    </tr>
+                                </apex:outputPanel>
                                 <tr class="eventTotalCost">
                                     <td class="slds-cell_action-mode"><strong>{!IF(ISBLANK(eventPage.Event_Fee_Total_Label__c),'Event Cost', eventPage.Event_Fee_Total_Label__c)}</strong></td>
                                     <td class="slds-text-align_right slds-cell_action-mode">

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -73,15 +73,24 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <apex:outputText escape="false" value="{!eventPage.Event_Confirmation_Description__c}"/>
                             </p>
                         </div>
-                        <apex:outputPanel layout="block" rendered="{!eventFees.size > 0}" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1">
 
-                            <outputPanel layout="none" rendered="{!paymentReceived}">
-                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Received</h3>
-                            </outputPanel>
+                        <apex:outputPanel layout="block" rendered="{!eventFees.size > 0}" styleClass="slds-col slds-p-vertical_x-small slds-size_1-of-1">
 
-                            <outputPanel layout="none" rendered="{!!paymentReceived}">
-                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Due</h3>
-                            </outputPanel>
+                            <apex:outputPanel layout="none" rendered="{!paymentReceived}">
+                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">{!IF(!ISBLANK(eventPage.Event_Payment_Received_Heading_Label__c), eventPage.Event_Payment_Received_Heading_Label__c, "Payment Received")}</h3>
+                                <apex:outputPanel layout="none" rendered="{!!ISBLANK(eventPage.Event_Payment_Received_Description__c)}">
+                                    <p class="slds-text-body slds-p-vertical_x-small">
+                                        <apex:outputText escape="false" value="{!EventPage.Event_Payment_Received_Description__c}"/>
+                                    </p>
+                                </apex:outputPanel>
+                            </apex:outputPanel>
+
+                            <apex:outputPanel layout="none" rendered="{!!paymentReceived}">
+                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">{!IF(!ISBLANK(eventPage.Event_Payment_Due_Heading_Label__c), eventPage.Event_Payment_Due_Heading_Label__c, "Payment Due")}</h3>
+                                <apex:outputPanel layout="block" rendered="{!!ISBLANK(eventPage.Event_Payment_Due_Description__c)}" styleClass="slds-text-body slds-p-vertical_small">
+                                    <apex:outputText escape="false" value="{!EventPage.Event_Payment_Due_Description__c}"/>
+                                </apex:outputPanel>
+                            </apex:outputPanel>
 
                             <table class="slds-table slds-table_cell-buffer slds-table_bordered">
                                 <tbody>

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -79,17 +79,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Received</h3>
                             </outputPanel>
 
+                            <outputPanel layout="none" rendered="{!!paymentReceived}">
+                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Due</h3>
+                            </outputPanel>
+
                             <table class="slds-table slds-table_cell-buffer slds-table_bordered">
-                                <thead>
-                                <tr class="slds-line-height_reset">
-                                    <th class="" scope="col">
-                                        <div class="slds-truncate" title="Item">Item</div>
-                                    </th>
-                                    <th class="" scope="col">
-                                        <div class="slds-truncate" title="Fee">Fee</div>
-                                    </th>
-                                </tr>
-                                </thead>
                                 <tbody>
                                 <apex:repeat value="{!eventFees}" var="fee">
                                     <apex:outputPanel rendered="{!fee.Event_Fee_Type__c != 'Event' && fee.Event_Fee_Type__c != 'Event Additional'}">

--- a/force-app/main/default/pages/SummitEventsConfirmation.page
+++ b/force-app/main/default/pages/SummitEventsConfirmation.page
@@ -73,8 +73,11 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <apex:outputText escape="false" value="{!eventPage.Event_Confirmation_Description__c}"/>
                             </p>
                         </div>
-                        <apex:outputPanel layout="block" rendered="{!hasFees}" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1">
-                            <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Received</h3>
+                        <apex:outputPanel layout="block" rendered="{!eventFees.size > 0}" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1">
+
+                            <outputPanel layout="none" rendered="{!paymentReceived}">
+                                <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">Payment Received</h3>
+                            </outputPanel>
 
                             <table class="slds-table slds-table_cell-buffer slds-table_bordered">
                                 <thead>
@@ -127,7 +130,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </tr>
                                 </apex:outputPanel>
                                 <tr class="eventTotalCost">
-                                    <td class="slds-cell_action-mode"><strong>{!IF(ISBLANK(eventPage.Event_Fee_Total_Label__c),'Event Cost', eventPage.Event_Fee_Total_Label__c)}</strong></td>
+                                    <td class="slds-cell_action-mode"><strong>{!IF(ISBLANK(eventPage.Event_Fee_Total_Label__c),'Balance Due', eventPage.Event_Fee_Total_Label__c)}</strong></td>
                                     <td class="slds-text-align_right slds-cell_action-mode">
                                         <strong>
                                             <apex:outputText value="${0,number,###,###,###,##0.00}">

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -557,7 +557,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <apex:input value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="preferredClassYear-required">
-                                    {!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', 'This field is required', '')}
+                                    {!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', 'Please enter a valid 4-digit value', '')}
                                 </div>
                             </div>
                         </apex:outputPanel>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -760,12 +760,12 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                             <apex:outputPanel layout="block" styleClass="slds-form-element__control">
 
                                                 <!--Text area -->
-                                                <apex:outputPanel layout="block" styleClass="slds-form-element__control" rendered="{!IF(CONTAINS(eventPage['Add_Info_Question_Type_' + q + '__c'], 'Text area'), true, false)}">
+                                                <apex:outputPanel layout="block" styleClass="slds-form-element__control" rendered="{!IF(CONTAINS(eventPage['Add_Info_Question_Type_' + q + '__c'], 'Text box'), true, false)}">
                                                     <apex:inputText value="{!eventRegistration['Add_Info_Answer_' + q + '__c']}" styleClass="slds-textarea"/>
                                                 </apex:outputPanel>
 
-                                                <!--Text box-->
-                                                <apex:outputPanel layout="block" styleClass="slds-form-element__control" rendered="{!IF(CONTAINS(eventPage['Add_Info_Question_Type_' + q + '__c'],'Text box'), true, false)}">
+                                                <!--Text area-->
+                                                <apex:outputPanel layout="block" styleClass="slds-form-element__control" rendered="{!IF(CONTAINS(eventPage['Add_Info_Question_Type_' + q + '__c'],'Text area'), true, false)}">
                                                     <apex:inputTextarea value="{!eventRegistration['Add_Info_Answer_' + q + '__c']}" styleClass="slds-input input-textbox"/>
                                                 </apex:outputPanel>
 

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -554,7 +554,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputText>
                                 </apex:outputLabel>
                                 <div class="slds-form-element__control">
-                                    <apex:input type="number" value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
+                                    <apex:input value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="preferredClassYear-required">
                                     {!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', 'This field is required', '')}

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -775,6 +775,10 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                                     </apex:selectList>
                                                 </apex:outputPanel>
 
+                                                <div class="slds-form-element__help" >
+                                                    {!IF(isRequired, 'This field is required', '')}
+                                                </div>
+
                                             </apex:outputPanel>
                                         </div>
                                     </div>

--- a/force-app/main/default/pages/SummitEventsRegister.page
+++ b/force-app/main/default/pages/SummitEventsRegister.page
@@ -540,7 +540,6 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                 <div class="slds-form-element__help" id="applicantType-required">
                                     {!IF(eventPage.Ask_Last_Name_As_Student__c == 'Ask and require', 'This field is required', '')}
                                 </div>
-                                <div class="slds-form-element__help" id="applicantType-required">This field is required</div>
                             </div>
                         </apex:outputPanel>
 
@@ -557,7 +556,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     <apex:input value="{!eventRegistration.Preferred_Class_Year__c}" html-aria-describedby="preferredClassYear-required" id="preferredClassYear" styleClass="slds-input validYear" required="{!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', true, false)}"/>
                                 </div>
                                 <div class="slds-form-element__help" id="preferredClassYear-required">
-                                    {!IF(eventPage.Ask_Preferred_Class_Year__c == 'Ask and require', 'Please enter a valid 4-digit value', '')}
+                                    Please enter a valid 4-digit value
                                 </div>
                             </div>
                         </apex:outputPanel>

--- a/force-app/main/default/pages/SummitEventsRegisterGuests.page
+++ b/force-app/main/default/pages/SummitEventsRegisterGuests.page
@@ -127,14 +127,14 @@
                     </button>
                     <div class="slds-modal__content slds-p-around_medium slds-modal__content_headless" id="modal-content-id-1">
                         <p>
-                            {!IF(ISBLANK(eventPage.Guest_Unsaved_Modal_Text__c),'ou have unsaved guest information entered. Do you wish to continue without saving?', eventPage.Guest_Unsaved_Modal_Text__c)}
+                            {!IF(ISBLANK(eventPage.Guest_Unsaved_Modal_Text__c),'You have unsaved Guest information entered. Select Cancel to finish adding your guests.', eventPage.Guest_Unsaved_Modal_Text__c)}
                         </p>
                     </div>
                     <div class="slds-modal__footer">
-                        <button class="slds-button slds-button_neutral cancelSubmit" aria-label="Cancel and close">
+                        <button class="slds-button slds-button_brand cancelSubmit" aria-label="Cancel and close">
                             {!IF(ISBLANK(eventPage.Guest_Unsaved_Cancel_Label__c),'Cancel', eventPage.Guest_Unsaved_Cancel_Label__c)}
                         </button>
-                        <button class="slds-button slds-button_brand continueSubmit">
+                        <button class="slds-button  slds-button_neutral continueSubmit">
                             {!IF(ISBLANK(eventPage.Guest_Unsaved_Continue_Label__c),'Continue', eventPage.Guest_Unsaved_Continue_Label__c)}
                         </button>
                     </div>

--- a/force-app/main/default/pages/SummitEventsRegisterGuests.page
+++ b/force-app/main/default/pages/SummitEventsRegisterGuests.page
@@ -105,7 +105,7 @@
                             <apex:inputHidden value="{!guestJSON}" id="guestJSON"/>
                             <div class="slds-col slds-size_1-of-1 slds-clearfix slds-p-vertical_x-small slds-p-vertical_xx-small">
                                 <p class="slds-text-body slds-p-vertical_xx-small">
-                                    <apex:commandLink action="{!saveGuests}" onClick="fadeout();" Value="Next" id="submitOptions" styleClass="slds-button slds-button_brand slds-p-horizontal_xx-large slds-p-vertical_xx-small"/>
+                                    <apex:commandLink action="{!saveGuests}" onClick="return saveGuestModal();" Value="Next" id="submitOptions" styleClass="slds-button slds-button_brand slds-p-horizontal_xx-large slds-p-vertical_xx-small"/>
                                     <apex:commandLink action="{!previousPage}" onClick="fadeout();" Value="Previous" id="previousPage" styleClass="slds-button slds-button_neutral slds-p-horizontal_xx-large slds-p-vertical_xx-small" immediate="true"/>
                                 </p>
                             </div>
@@ -116,6 +116,26 @@
                     </apex:outputPanel>
                 </div>
             </div>
+
+            <section role="dialog" tabindex="-1" aria-modal="true" aria-label="Meaningful description of the modal content" class="slds-modal" id="unsavedGuestModal">
+                <div class="slds-modal__container">
+                    <button class="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse cancelSubmit">
+                        <svg class="slds-button__icon slds-button__icon_large" aria-hidden="true">
+                            <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/apexpages/slds/latest/assets/icons/utility-sprite/svg/symbols.svg#close"></use>
+                        </svg>
+                        <span class="slds-assistive-text">Cancel and close</span>
+                    </button>
+                    <div class="slds-modal__content slds-p-around_medium slds-modal__content_headless" id="modal-content-id-1">
+                        <p>You have unsaved guest information entered. Do you wish to continue without saving?</p>
+                    </div>
+                    <div class="slds-modal__footer">
+                        <button class="slds-button slds-button_neutral cancelSubmit" aria-label="Cancel and close">Cancel</button>
+                        <button class="slds-button slds-button_brand continueSubmit">Continue</button>
+                    </div>
+                </div>
+            </section>
+            <div class="slds-backdrop" role="presentation" id="unsavedGuestBackground"></div>
+
         </apex:define>
 
     </apex:composition>

--- a/force-app/main/default/pages/SummitEventsRegisterGuests.page
+++ b/force-app/main/default/pages/SummitEventsRegisterGuests.page
@@ -126,11 +126,17 @@
                         <span class="slds-assistive-text">Cancel and close</span>
                     </button>
                     <div class="slds-modal__content slds-p-around_medium slds-modal__content_headless" id="modal-content-id-1">
-                        <p>You have unsaved guest information entered. Do you wish to continue without saving?</p>
+                        <p>
+                            {!IF(ISBLANK(eventPage.Guest_Unsaved_Modal_Text__c),'ou have unsaved guest information entered. Do you wish to continue without saving?', eventPage.Guest_Unsaved_Modal_Text__c)}
+                        </p>
                     </div>
                     <div class="slds-modal__footer">
-                        <button class="slds-button slds-button_neutral cancelSubmit" aria-label="Cancel and close">Cancel</button>
-                        <button class="slds-button slds-button_brand continueSubmit">Continue</button>
+                        <button class="slds-button slds-button_neutral cancelSubmit" aria-label="Cancel and close">
+                            {!IF(ISBLANK(eventPage.Guest_Unsaved_Cancel_Label__c),'Cancel', eventPage.Guest_Unsaved_Cancel_Label__c)}
+                        </button>
+                        <button class="slds-button slds-button_brand continueSubmit">
+                            {!IF(ISBLANK(eventPage.Guest_Unsaved_Continue_Label__c),'Continue', eventPage.Guest_Unsaved_Continue_Label__c)}
+                        </button>
                     </div>
                 </div>
             </section>

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -137,7 +137,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
                         </div>
 
-                        <apex:outputPanel layout="block" rendered="{!hasFees}" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1">
+                        <apex:outputPanel layout="block" rendered="{!eventFees.size > 0}" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1">
                             <h3 class="slds-text-heading_medium slds-p-vertical_xx-small">{!IF(ISBLANK(eventPage.Event_Fee_Submit_List_Label__c),'Event Charges', eventPage.Event_Fee_Submit_List_Label__c)}</h3>
 
                             <table class="slds-table slds-table_cell-buffer slds-table_bordered slds-table_col-bordered">
@@ -171,7 +171,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                                     </apex:outputPanel>
                                 </apex:repeat>
                                 <tr class="eventTotalCost">
-                                    <td class="slds-cell_action-mode"><strong>{!IF(ISBLANK(eventPage.Event_Fee_Total_Label__c),'Event Cost', eventPage.Event_Fee_Total_Label__c)}</strong></td>
+                                    <td class="slds-cell_action-mode"><strong>{!IF(ISBLANK(eventPage.Event_Fee_Total_Label__c),'Total', eventPage.Event_Fee_Total_Label__c)}</strong></td>
                                     <td class="slds-text-align_right slds-cell_action-mode">
                                         <strong>
                                             <apex:outputText value="${0,number,###,###,###,##0.00}">

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -2074,6 +2074,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Event_Fees_Received_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Event_Footer__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -909,6 +909,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events_Question__c.Picklist_Values_Long__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events_Question__c.Picklist_Values__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1660,6 +1665,31 @@
     <fieldPermissions>
         <editable>true</editable>
         <field>Summit_Events__c.Add_Info_Question_Pick_List_5__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_1__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_3__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_4__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_5__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -2114,6 +2114,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Event_Payment_Due_Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Event_Payment_Due_Heading_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Event_Payment_Received_Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Event_Payment_Received_Heading_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Event_Short_Listing_Description__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Admin.permissionset-meta.xml
@@ -2199,6 +2199,21 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>true</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Cancel_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Continue_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Modal_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
         <field>Summit_Events__c.Hand_Raise_Action__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1952,6 +1952,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Event_Fees_Received_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Event_Footer__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -1992,6 +1992,26 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Event_Payment_Due_Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Event_Payment_Due_Heading_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Event_Payment_Received_Description__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Event_Payment_Received_Heading_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Event_Short_Listing_Description__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -787,6 +787,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events_Question__c.Picklist_Values_Long__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events_Question__c.Picklist_Values__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -1538,6 +1543,31 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>Summit_Events__c.Add_Info_Question_Pick_List_5__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_1__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_2__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_3__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_4__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Add_Info_Question_Pick_List_Long_5__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Summit_Events_Registrant.permissionset-meta.xml
@@ -2077,6 +2077,21 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Cancel_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Continue_Label__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Summit_Events__c.Guest_Unsaved_Modal_Text__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>Summit_Events__c.Hand_Raise_Action__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/force-app/main/default/staticresources/SummitEventsAssets/css/main.css
+++ b/force-app/main/default/staticresources/SummitEventsAssets/css/main.css
@@ -126,6 +126,10 @@ textarea {
     border: solid 1px red;
 }
 
+.slds-scope .slds-has-info .slds-input {
+    border-width: 2px;
+}
+
 /*Loading image*/
 #backpage {
     display: none;
@@ -170,7 +174,7 @@ textarea {
     font-size: 1em;
 }
 
-.slds-form-element.slds-has-error .slds-form-element__help {
+.slds-form-element.slds-has-error .slds-form-element__help, .slds-form-element.slds-has-info .slds-form-element__help {
     display: block;
 }
 

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/guestRegistration.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/guestRegistration.js
@@ -307,6 +307,45 @@ function removeById(idToRemove, element) {
     setGuestRemaining();
 }
 
+function saveGuestModal() {
+    let form = document.getElementById('guestInput');
+    let allInputs = form.querySelectorAll('input, select, textarea');
+    let submitButton = document.querySelector("[id$='submitOptions']");
+    let noValues = true;
+    let modalElem = document.getElementById('unsavedGuestModal');
+    let modalBack = document.getElementById('unsavedGuestBackground');
+    allInputs.forEach(input => {
+        if (input.value) {
+            noValues = false;
+        }
+    });
+    if (!noValues) {
+        modalElem.classList.add('slds-fade-in-open');
+        modalBack.classList.add('slds-fade-in-open');
+        modalElem.querySelectorAll('.cancelSubmit').forEach(cancel => {
+            cancel.addEventListener('click', () => {
+                modalElem.classList.remove('slds-fade-in-open');
+                modalBack.classList.remove('slds-fade-in-open');
+            });
+        })
+    }
+    modalElem.querySelectorAll('.continueSubmit').forEach(submit => {
+        submit.addEventListener('click', () => {
+            modalElem.classList.remove('slds-fade-in-open');
+            modalBack.classList.remove('slds-fade-in-open');
+            allInputs.forEach(input => {
+                input.value = '';
+            });
+            submitButton.click();
+        })
+    });
+    if (noValues) {
+        fadeout();
+    }
+    return noValues;
+    //fadeout();
+}
+
 
 //Templates
 
@@ -349,25 +388,4 @@ const answerTemplate = (question, answer) => `
         ${answer}
     </div>
 </div>
-`;
-
-const resultListTemplate = (modalId, title, text, actionButtonTitle, cancelButtonTitle, action) => `
-<section role="dialog" tabIndex="-1" aria-modal="true" aria-label="${title}" className="slds-modal slds-fade-in-open" id="${modalId}">
-    <div className="slds-modal__container">
-        <button className="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse">
-            <svg className="slds-button__icon slds-button__icon_large" aria-hidden="true">
-                <use xlink:href="/assets/icons/utility-sprite/svg/symbols.svg#close"></use>
-            </svg>
-            <span className="slds-assistive-text">Cancel and close</span>
-        </button>
-        <div className="slds-modal__content slds-p-around_medium slds-modal__content_headless" id="modal-content-id-1">
-            <p>${text}</p>
-        </div>
-        <div className="slds-modal__footer">
-            <button className="slds-button slds-button_neutral" aria-label="Cancel and close">${cancelButtonTitle}</button>
-            <button class="slds-button slds-button_brand" onclick="${action}">${actionButtonTitle}</button>
-        </div>
-    </div>
-</section>
-<div class="slds-backdrop slds-backdrop_open" role="presentation"></div>
 `;

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/guestRegistration.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/guestRegistration.js
@@ -350,3 +350,24 @@ const answerTemplate = (question, answer) => `
     </div>
 </div>
 `;
+
+const resultListTemplate = (modalId, title, text, actionButtonTitle, cancelButtonTitle, action) => `
+<section role="dialog" tabIndex="-1" aria-modal="true" aria-label="${title}" className="slds-modal slds-fade-in-open" id="${modalId}">
+    <div className="slds-modal__container">
+        <button className="slds-button slds-button_icon slds-modal__close slds-button_icon-inverse">
+            <svg className="slds-button__icon slds-button__icon_large" aria-hidden="true">
+                <use xlink:href="/assets/icons/utility-sprite/svg/symbols.svg#close"></use>
+            </svg>
+            <span className="slds-assistive-text">Cancel and close</span>
+        </button>
+        <div className="slds-modal__content slds-p-around_medium slds-modal__content_headless" id="modal-content-id-1">
+            <p>${text}</p>
+        </div>
+        <div className="slds-modal__footer">
+            <button className="slds-button slds-button_neutral" aria-label="Cancel and close">${cancelButtonTitle}</button>
+            <button class="slds-button slds-button_brand" onclick="${action}">${actionButtonTitle}</button>
+        </div>
+    </div>
+</section>
+<div class="slds-backdrop slds-backdrop_open" role="presentation"></div>
+`;

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
@@ -10,8 +10,7 @@ let audience;
 const overlay = createSpinner();
 
 let ready = (callback) => {
-    if (document.readyState != "loading") callback();
-    else document.addEventListener("DOMContentLoaded", callback);
+    if (document.readyState != "loading") callback(); else document.addEventListener("DOMContentLoaded", callback);
 }
 
 ready(() => {
@@ -151,56 +150,63 @@ function fillInCityStateOnZip(zipObj) {
     } else {
         url = url + zip;
     }
-
-    let cityState = document.querySelectorAll('input[id$=city], select[id$=state]');
-    cityState.forEach(function (cs) {
-        let formElem = cs.closest(".slds-form-element");
-        if (formElem !== null) {
-            formElem.append(overlay.cloneNode(true));
-        }
-    });
+    formOverlay(false);
 
     fetch(url)
         .then((response) => response.json())
-        .then((result) => {
-            if (result) {
-                let city = result[0].address.city;
-                if (city == null) {
-                    city = result[0].address.hamlet;
-                }
-                if (city == null) {
-                    city = result[0].address.town;
-                }
-                let state = result[0].address.state;
-                if (state == null) {
-                    state = result[0].address.county;
-                }
+        .then((results) => {
+            if (results) {
+                if (results.length > 0) {
+                    result = results[0];
 
-                for (let [key, value] of Object.entries(RFIStates)) {
-                    if (value === state) {
-                        state = key;
+                    let city = '';
+
+                    city = result.address.city ? result.address.city : '';
+                    city = !city && result.address.hamlet ? result.address.hamlet : city;
+                    city = !city && result.address.town ? result.address.town : city;
+
+                    let state = result.address.state ? result.address.state : '';
+                    stat = !state && result.address.county ? result.address.county : state;
+
+                    for (let [key, value] of Object.entries(RFIStates)) {
+                        if (value === state) {
+                            state = key;
+                        }
+                    }
+                    let county = result.address.county ? result.address.county : '';
+                    let country = result.address.country_code.toUpperCase() ? result.address.country_code.toUpperCase() : '';
+
+                    let cityInput = document.querySelector('[id$=city]');
+                    let stateInput = document.querySelector('[id$=state]');
+                    if (cityInput) {
+                        cityInput.value = city;
+                    }
+                    if (stateInput) {
+                        stateInput.value = state;
                     }
                 }
-                let county = result[0].address.county;
-                let country = result[0].address.country_code.toUpperCase();
-                let cityInput = document.querySelector('[id$=city]');
-                let stateInput = document.querySelector('[id$=state]');
-                if (cityInput) {
-                    cityInput.value = city;
-                }
-                if (stateInput) {
-                    stateInput.value = state;
-                }
             }
-            cityState.forEach(function (cs) {
-                let formElem = cs.closest(".slds-form-element");
+            formOverlay(true);
+        }).catch(error => {
+        console.log(error);
+        formOverlay(true);
+    });
+
+    function formOverlay(remove) {
+        let cityState = document.querySelectorAll('input[id$=city], select[id$=state]');
+        cityState.forEach(function (cs) {
+            let formElem = cs.closest(".slds-form-element");
+            if (remove) {
                 formElem.querySelectorAll('.waiting-overlay').forEach(function (wa) {
                     wa.remove();
                 });
-            });
-        }).catch(error => {
-
-    });
+            } else {
+                if (formElem !== null) {
+                    formElem.append(overlay.cloneNode(true));
+                }
+            }
+        });
+    }
 }
 
 function formatPhone(phone) {
@@ -339,10 +345,8 @@ function readCookie(name) {
     var ca = document.cookie.split(';');
     for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
-        while (c.charAt(0) === ' ')
-            c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) === 0)
-            return decodeURIComponent(c.substring(nameEQ.length, c.length));
+        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) return decodeURIComponent(c.substring(nameEQ.length, c.length));
     }
     return null;
 }
@@ -352,10 +356,8 @@ function eraseCookie(name) {
 }
 
 var getUrlParameter = function getUrlParameter(sParam) {
-    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
-        sURLVariables = sPageURL.split('&'),
-        sParameterName,
-        i;
+    var sPageURL = decodeURIComponent(window.location.search.substring(1)), sURLVariables = sPageURL.split('&'),
+        sParameterName, i;
 
     for (i = 0; i < sURLVariables.length; i++) {
         sParameterName = sURLVariables[i].split('=');

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
@@ -96,9 +96,6 @@ function checkForm() {
 
             if (inputRequired && !item.value) {
                 inputWrap.classList.add("slds-has-error");
-                inputWrap.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
-                    errorHelp.style.display = "block"
-                });
                 addErrorFixerListener(item, inputWrap, 'change');
                 error_count++;
             }
@@ -135,10 +132,14 @@ function checkForm() {
 
 function addErrorFixerListener(inpt, wrp, evtType) {
     inpt.addEventListener(evtType, (e) => {
-        wrp.classList.remove("slds-has-error");
-        wrp.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
-            errorHelp.style.display = "none";
-        });
+        if (!inpt.classList.contains('validYear')) {
+            wrp.classList.remove("slds-has-error");
+        } else {
+            let re = new RegExp(/(19|20)\d{2}/);
+            if (re.test(inpt.value)) {
+                wrp.classList.remove("slds-has-error");
+            }
+        }
     });
 }
 
@@ -230,15 +231,9 @@ function formatPhone(phone) {
 function validYear() {
     let yearsToValidate = document.querySelectorAll('.validYear');
     yearsToValidate.forEach(function (yr) {
-
         let yrWrap = yr.closest('.slds-form-element');
+        let inputRequired = yrWrap.classList.contains('slds-is-required');
         yr.addEventListener("keyup", (e) => {
-            if (yrWrap.classList.contains('slds-has-error')) {
-                yrWrap.classList.remove('slds-has-error');
-            }
-            yrWrap.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
-                errorHelp.style.display = "none"
-            });
             yr.value = (yr.value.replace(/\D/g, ''));
             if (yr.value.length > 4) {
                 yr.value = yr.value.slice(0, 4);
@@ -246,17 +241,19 @@ function validYear() {
         });
         yr.addEventListener("change", (e) => {
             let re = new RegExp(/(19|20)\d{2}/);
-            if(yr.value) {
+            yrWrap.classList.remove('slds-has-error');
+            yrWrap.classList.remove('slds-has-info');
+            if (yr.value) {
                 if (!re.test(yr.value)) {
                     yr.value = '';
-                    yrWrap.classList.add('slds-has-error');
-                    yrWrap.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
-                        errorHelp.style.display = "block"
-                    });
+                    if (inputRequired) {
+                        yrWrap.classList.add('slds-has-error');
+                    } else {
+                        yrWrap.classList.add('slds-has-info');
+                    }
                 }
             }
         });
-
     });
 }
 

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/register.js
@@ -230,6 +230,7 @@ function formatPhone(phone) {
 function validYear() {
     let yearsToValidate = document.querySelectorAll('.validYear');
     yearsToValidate.forEach(function (yr) {
+
         let yrWrap = yr.closest('.slds-form-element');
         yr.addEventListener("keyup", (e) => {
             if (yrWrap.classList.contains('slds-has-error')) {
@@ -245,14 +246,17 @@ function validYear() {
         });
         yr.addEventListener("change", (e) => {
             let re = new RegExp(/(19|20)\d{2}/);
-            if (!re.test(yr.value)) {
-                yr.value = '';
-                yrWrap.classList.add('slds-has-error');
-                yrWrap.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
-                    errorHelp.style.display = "block"
-                });
+            if(yr.value) {
+                if (!re.test(yr.value)) {
+                    yr.value = '';
+                    yrWrap.classList.add('slds-has-error');
+                    yrWrap.querySelectorAll(".slds-form-element__help").forEach(errorHelp => {
+                        errorHelp.style.display = "block"
+                    });
+                }
             }
         });
+
     });
 }
 

--- a/force-app/test/default/classes/SummitEventsAddToCalendar_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsAddToCalendar_TEST.cls
@@ -117,8 +117,7 @@ public class SummitEventsAddToCalendar_TEST {
             Test.setCurrentPage(pageRef);
             SummitEventsAddToCalendarController calendarController = new SummitEventsAddToCalendarController();
 
-            SummitEventsShared SEShared = new SummitEventsShared();
-            String timezoneString = SEShared.getTimeZonePick(seaTestInstances[1].Instance_Time_Zone__c);
+            String timezoneString = SummitEventsShared.getTimeZonePick(seaTestInstances[1].Instance_Time_Zone__c);
             TimeZone tz = TimeZone.getTimeZone(timezoneString);
             Date startD = seaTestInstances[1].Instance_Start_Date__c;
             Time startT = seaTestInstances[1].Instance_Start_Time__c;

--- a/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
@@ -27,7 +27,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             //No cookie present so page redirects to root of Summit Events and event info is null
             PageReference eventPage = questionController.checkEventDetails();
             System.assertEquals(eventPage.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
-            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"registrationId":null,"instanceId":null,"eventId":null,"dt":null,"audience":null}');
+            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"valid":null,"registrationId":null,"instanceId":null,"eventId":null,"dt":null,"audience":null}');
 
             Test.stopTest();
         }
@@ -47,7 +47,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
             //Page stays where it is because cookie present
@@ -55,7 +55,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             System.assertEquals(eventPage, null);
 
             //Correct encrypted cooke information decrypted
-            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
 
             //No questions were set up for this page
             System.assertEquals(questionController.additionalQuestions.size(), 0);
@@ -87,7 +87,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 
@@ -95,7 +95,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             PageReference previousPage = questionController.previousPage();
             System.assertEquals(previousPage.getUrl(), '/apex/' + namespace + 'summiteventsregister?adminopen=true');
 
-            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
             //All questions types represented here (if number of types increases this will have to be adjusted)
             System.assertEquals(questionController.additionalQuestions.size(), 9);
 
@@ -129,12 +129,12 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 
             //Checking that the cookie returns the correct information
-            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(questionController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
 
             //Only 1 lookup questions requested so additional question query and wrapper should be 1
             System.assertEquals(questionController.additionalQuestions.size(), 1);
@@ -183,7 +183,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
             //Test question with field that doesn't exist for map_to_field__c
@@ -231,7 +231,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
             testQuestions[0].Lookup_Object__c = 'Blah';
             testQuestions[0].Lookup_Fields__c = 'Blah';
             update testQuestions;
@@ -269,7 +269,7 @@ private class SummitEventsAdditionalQuestions_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 

--- a/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsAdditionalQuestions_TEST.cls
@@ -46,9 +46,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             PageReference pageRef = Page.SummitEventsAdditionalQuestions;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
             //Page stays where it is because cookie present
@@ -87,9 +86,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 
@@ -130,10 +128,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
 
-
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 
@@ -186,9 +182,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             PageReference pageRef = Page.SummitEventsAdditionalQuestions;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
             //Test question with field that doesn't exist for map_to_field__c
@@ -235,9 +230,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             PageReference pageRef = Page.SummitEventsAdditionalQuestions;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
             testQuestions[0].Lookup_Object__c = 'Blah';
             testQuestions[0].Lookup_Fields__c = 'Blah';
             update testQuestions;
@@ -274,9 +268,8 @@ private class SummitEventsAdditionalQuestions_TEST {
             PageReference pageRef = Page.SummitEventsAdditionalQuestions;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsAdditionalQuestionsCtlr questionController = new SummitEventsAdditionalQuestionsCtlr();
 

--- a/force-app/test/default/classes/SummitEventsCancelReview_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsCancelReview_TEST.cls
@@ -10,8 +10,7 @@ private class SummitEventsCancelReview_TEST {
         List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        SummitEventsShared SEAShared = new SummitEventsShared();
-        String encryptedString = SEAShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         if (encryptedString.length() > 255) {
             seaTestRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -49,8 +48,7 @@ private class SummitEventsCancelReview_TEST {
         List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        SummitEventsShared SEAShared = new SummitEventsShared();
-        String encryptedString = SEAShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         if (encryptedString.length() > 255) {
             seaTestRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -66,7 +64,7 @@ private class SummitEventsCancelReview_TEST {
             PageReference pageRef = Page.SummitEventsCancelReview;
             pageRef.getParameters().put('eventInfo', seaTestRegistration.Encrypted_Registration_Id_1__c + seaTestRegistration.Encrypted_Registration_Id_2__c);
             Test.setCurrentPage(pageRef);
-            String encryptedRegistrationId = SEAShared.createEncryptedCookie('', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            String encryptedRegistrationId = SummitEventsShared.createEncryptedCookie('', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             ApexPages.currentPage().getParameters().put('eventInfo', encryptedRegistrationId + 'TAMPER');
             SummitEventsCancelReviewController cancelReviewCtrl = new SummitEventsCancelReviewController();
             cancelReviewCtrl.cancelRegistration();

--- a/force-app/test/default/classes/SummitEventsCancelReview_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsCancelReview_TEST.cls
@@ -10,7 +10,7 @@ private class SummitEventsCancelReview_TEST {
         List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id, true);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         if (encryptedString.length() > 255) {
             seaTestRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -48,7 +48,7 @@ private class SummitEventsCancelReview_TEST {
         List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id, true);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         if (encryptedString.length() > 255) {
             seaTestRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);
@@ -64,7 +64,7 @@ private class SummitEventsCancelReview_TEST {
             PageReference pageRef = Page.SummitEventsCancelReview;
             pageRef.getParameters().put('eventInfo', seaTestRegistration.Encrypted_Registration_Id_1__c + seaTestRegistration.Encrypted_Registration_Id_2__c);
             Test.setCurrentPage(pageRef);
-            String encryptedRegistrationId = SummitEventsShared.createEncryptedCookie('', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            String encryptedRegistrationId = SummitEventsShared.createEncryptedCookie('', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             ApexPages.currentPage().getParameters().put('eventInfo', encryptedRegistrationId + 'TAMPER');
             SummitEventsCancelReviewController cancelReviewCtrl = new SummitEventsCancelReviewController();
             cancelReviewCtrl.cancelRegistration();

--- a/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
@@ -14,7 +14,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, evtReg.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, evtReg.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.eventIsClosed = false;
             confirmCtrl.checkEventDetails();
@@ -63,7 +63,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', '1');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.checkEventDetails();
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -88,7 +88,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
 
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.checkEventDetails();
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -136,7 +136,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             confirmCtrl.checkEventDetails();
@@ -204,7 +204,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -217,7 +217,7 @@ private class SummitEventsConfirmation_TEST {
 
             Test.startTest();
 
-            PageReference confirmPageReg = confirmCtrl.gatherPaymentInformation();
+            PageReference confirmPageReg = confirmCtrl.checkForPayment();
             System.assertEquals(confirmPageReg, null);
 
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -275,7 +275,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -317,7 +317,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -329,7 +329,7 @@ private class SummitEventsConfirmation_TEST {
             }
 
             Test.startTest();
-            PageReference confirmPageReg = confirmCtrl.gatherPaymentInformation();
+            PageReference confirmPageReg = confirmCtrl.checkForPayment();
             System.assertEquals(confirmPageReg.getParameters().get('error'), 'Payment+was+not+received.+Please+try+again.');
 
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -384,7 +384,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             confirmCtrl.checkEventDetails();

--- a/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsConfirmation_TEST.cls
@@ -14,8 +14,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, evtReg.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, evtReg.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.eventIsClosed = false;
             confirmCtrl.checkEventDetails();
@@ -64,8 +63,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', '1');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.checkEventDetails();
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -90,8 +88,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
 
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
             confirmCtrl.checkEventDetails();
             Summit_Events_Registration__c checkRegistrationStatus = [
@@ -139,8 +136,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             confirmCtrl.checkEventDetails();
@@ -208,8 +204,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -280,8 +275,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -323,8 +317,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             List<String> pageMessages = new List<String>();
@@ -391,8 +384,7 @@ private class SummitEventsConfirmation_TEST {
             PageReference pageRef = Page.SummitEventsConfirmation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsConfirmationController confirmCtrl = new SummitEventsConfirmationController();
 
             confirmCtrl.checkEventDetails();

--- a/force-app/test/default/classes/SummitEventsDonation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsDonation_TEST.cls
@@ -17,8 +17,7 @@ private class SummitEventsDonation_TEST {
             PageReference pageRef = Page.SummitEventsDonation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared seaShared = new SummitEventsShared();
-            seaShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsDonationController donationController = new SummitEventsDonationController();
 
             System.assert(donationController.getDonationAllocationList().size() > 0);

--- a/force-app/test/default/classes/SummitEventsDonation_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsDonation_TEST.cls
@@ -17,7 +17,7 @@ private class SummitEventsDonation_TEST {
             PageReference pageRef = Page.SummitEventsDonation;
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsDonationController donationController = new SummitEventsDonationController();
 
             System.assert(donationController.getDonationAllocationList().size() > 0);

--- a/force-app/test/default/classes/SummitEventsFeed_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsFeed_TEST.cls
@@ -160,11 +160,12 @@ private class SummitEventsFeed_TEST {
             RestContext.request = req;
             RestContext.response = res;
             SummitEventsFeed.getSummitEventsFeed();
-
+            Test.startTest();
             System.assert(res.responseBody.toString().contains('testingAnOverride.com'));
             System.assert(res.responseBody.toString().contains('New location override'));
             System.assert(res.responseBody.toString().contains('Map link override'));
             System.assert(res.responseBody.toString().contains('New button override'));
+            Test.stopTest();
         }
     }
 }

--- a/force-app/test/default/classes/SummitEventsParkingPass_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsParkingPass_TEST.cls
@@ -11,8 +11,8 @@ private class SummitEventsParkingPass_TEST {
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[2], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         Summit_Events_Registration__c seaTestRegistration2 = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst2', 'TestLast2', 'test2@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
-        String encryptedString2 = SummitEventsShared.createEncryptedCookie('', seaTestRegistration2.Event_Instance__c, seaTestRegistration2.Event__c, seaTestRegistration2.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id, true);
+        String encryptedString2 = SummitEventsShared.createEncryptedCookie('', seaTestRegistration2.Event_Instance__c, seaTestRegistration2.Event__c, seaTestRegistration2.Id, true);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         encryptedString2 = EncodingUtil.urlDecode(encryptedString2, 'UTF-8');
         if (encryptedString.length() > 255) {

--- a/force-app/test/default/classes/SummitEventsParkingPass_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsParkingPass_TEST.cls
@@ -11,9 +11,8 @@ private class SummitEventsParkingPass_TEST {
         Summit_Events_Registration__c seaTestRegistration = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[2], 'TestFirst', 'TestLast', 'test@valleyhill.net', '55418', '1971-03-22', '2012', null);
         Summit_Events_Registration__c seaTestRegistration2 = SummitEventsTestSharedDataFactory.createEventRegistration(seaTestInstances[1], 'TestFirst2', 'TestLast2', 'test2@valleyhill.net', '55418', '1971-03-22', '2012', null);
         User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User', 'Summit_Events_Registrant');
-        SummitEventsShared SEAShared = new SummitEventsShared();
-        String encryptedString = SEAShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
-        String encryptedString2 = SEAShared.createEncryptedCookie('', seaTestRegistration2.Event_Instance__c, seaTestRegistration2.Event__c, seaTestRegistration2.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', seaTestRegistration.Event_Instance__c, seaTestRegistration.Event__c, seaTestRegistration.Id);
+        String encryptedString2 = SummitEventsShared.createEncryptedCookie('', seaTestRegistration2.Event_Instance__c, seaTestRegistration2.Event__c, seaTestRegistration2.Id);
         encryptedString = EncodingUtil.urlDecode(encryptedString, 'UTF-8');
         encryptedString2 = EncodingUtil.urlDecode(encryptedString2, 'UTF-8');
         if (encryptedString.length() > 255) {

--- a/force-app/test/default/classes/SummitEventsRegisterAppointment_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegisterAppointment_TEST.cls
@@ -31,7 +31,7 @@ private class SummitEventsRegisterAppointment_TEST {
             PageReference checkPage = optionsCtrl.checkEventDetails();
             System.assertEquals(checkPage.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             optionsCtrl = new SummitEventsRegisterAppointmentCtlr();
 
             //Check event details should return null because event

--- a/force-app/test/default/classes/SummitEventsRegisterAppointment_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegisterAppointment_TEST.cls
@@ -31,8 +31,7 @@ private class SummitEventsRegisterAppointment_TEST {
             PageReference checkPage = optionsCtrl.checkEventDetails();
             System.assertEquals(checkPage.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             optionsCtrl = new SummitEventsRegisterAppointmentCtlr();
 
             //Check event details should return null because event

--- a/force-app/test/default/classes/SummitEventsRegisterGuests_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegisterGuests_TEST.cls
@@ -27,8 +27,6 @@ private class SummitEventsRegisterGuests_TEST {
         //Test question with empty map_to_field defined.
         List<Summit_Events_Question__c> testQuestions = SummitEventsTestSharedDataFactory.addQuestionsToEvent(seaTestInstances[1].Event__c, 'Text Area', 'Guest');
 
-        SummitEventsShared seaShared = new SummitEventsShared();
-
         String namespace = SummitEventsNamespace.getNamespace();
         if (String.isNotBlank(namespace)) {
             namespace = namespace + '__';
@@ -47,9 +45,8 @@ private class SummitEventsRegisterGuests_TEST {
             PageReference pageCheck = guestController.checkEventDetails();
             System.assertEquals(pageCheck.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
 
             guestController = new SummitEventsRegisterGuestsController();
@@ -67,7 +64,7 @@ private class SummitEventsRegisterGuests_TEST {
             List<SummitEventsRegisterGuestsController.questionData> questionsDataList = new List<SummitEventsRegisterGuestsController.questionData>();
 
             SummitEventsRegisterGuestsController.questionData questionData = new SummitEventsRegisterGuestsController.questionData();
-            questionData.id = seaShared.encryptString(testQuestions[0].Id);
+            questionData.id = SummitEventsShared.encryptString(testQuestions[0].Id);
             questionData.value = 'TEST';
             questionData.question = testQuestions[0].Question_Label__c;
             questionsDataList.add(questionData);
@@ -105,8 +102,6 @@ private class SummitEventsRegisterGuests_TEST {
         testQuestions2[0].Is_Visible__c = false;
         update testQuestions2;
 
-        SummitEventsShared seaShared = new SummitEventsShared();
-
         String namespace = SummitEventsNamespace.getNamespace();
         if (String.isNotBlank(namespace)) {
             namespace = namespace + '__';
@@ -127,9 +122,8 @@ private class SummitEventsRegisterGuests_TEST {
             //Namespace defined so url should include it
             System.assertEquals(pageCheck.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             guestController = new SummitEventsRegisterGuestsController();
 
@@ -148,7 +142,7 @@ private class SummitEventsRegisterGuests_TEST {
             List<SummitEventsRegisterGuestsController.questionData> questionsDataList = new List<SummitEventsRegisterGuestsController.questionData>();
 
             SummitEventsRegisterGuestsController.questionData questionData = new SummitEventsRegisterGuestsController.questionData();
-            questionData.id = seaShared.encryptString(testQuestions[0].Id);
+            questionData.id = SummitEventsShared.encryptString(testQuestions[0].Id);
             questionData.value = 'TEST';
             questionData.question = testQuestions[0].Question_Label__c;
             questionsDataList.add(questionData);
@@ -199,9 +193,8 @@ private class SummitEventsRegisterGuests_TEST {
             PageReference pageRef = Page.SummitEventsRegisterGuests;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsRegisterGuestsController guestController = new SummitEventsRegisterGuestsController();
 
@@ -245,9 +238,8 @@ private class SummitEventsRegisterGuests_TEST {
             PageReference pageRef = Page.SummitEventsRegisterGuests;
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
             Datetime nowTime = Datetime.now();
-            SEShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
 
             SummitEventsRegisterGuestsController guestController = new SummitEventsRegisterGuestsController();
 

--- a/force-app/test/default/classes/SummitEventsRegisterGuests_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegisterGuests_TEST.cls
@@ -13,7 +13,7 @@ private class SummitEventsRegisterGuests_TEST {
         Test.setCurrentPage(pageRef);
 
         SummitEventsRegisterGuestsController guestController = new SummitEventsRegisterGuestsController();
-        System.assertEquals(JSON.serialize(guestController.eventInformation), '{"registrationId":null,"instanceId":null,"eventId":null,"dt":null,"audience":null}');
+        System.assertEquals(JSON.serialize(guestController.eventInformation), '{"valid":null,"registrationId":null,"instanceId":null,"eventId":null,"dt":null,"audience":null}');
 
     }
 
@@ -46,7 +46,7 @@ private class SummitEventsRegisterGuests_TEST {
             System.assertEquals(pageCheck.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
 
             guestController = new SummitEventsRegisterGuestsController();
@@ -56,7 +56,7 @@ private class SummitEventsRegisterGuests_TEST {
             System.assertEquals(pageCheck, null);
 
             //Correct encrypted cooke information decrypted
-            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
 
             //Create question answer JSON object
             List<SummitEventsRegisterGuestsController.questionGuestData> guestsQuestions = new List<SummitEventsRegisterGuestsController.questionGuestData>();
@@ -123,7 +123,7 @@ private class SummitEventsRegisterGuests_TEST {
             System.assertEquals(pageCheck.getUrl(), 'https://google.com/' + namespace + 'SummitEvents');
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime, true);
 
             guestController = new SummitEventsRegisterGuestsController();
 
@@ -134,7 +134,7 @@ private class SummitEventsRegisterGuests_TEST {
             System.assertEquals(guestController.previousPage().getUrl(), '/apex/' + namespace + 'summiteventsregister?adminopen=true');
 
             //Correct encrypted cooke information decrypted
-            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
 
             //Create question answer JSON object
             List<SummitEventsRegisterGuestsController.questionGuestData> guestsQuestions = new List<SummitEventsRegisterGuestsController.questionGuestData>();
@@ -194,7 +194,7 @@ private class SummitEventsRegisterGuests_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime,true);
 
             SummitEventsRegisterGuestsController guestController = new SummitEventsRegisterGuestsController();
 
@@ -204,7 +204,7 @@ private class SummitEventsRegisterGuests_TEST {
             System.assertEquals(guestQuestions[1].setupError, 'Field ' + namespace + 'Total_Confirmed_Appointments__c is not writable. ');
 
             //Correct encrypted cooke information decrypted
-            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
+            System.assertEquals(JSON.serialize(guestController.eventInformation), '{"valid":"true","registrationId":"' + seaTestRegistration.Id + '","instanceId":"' + seaTestInstances[1].Id + '","eventId":"' + seaTestInstances[1].Event__c + '","dt":"' + String.valueOf(nowTime) + '","audience":"Transfer"}');
 
 
             Test.stopTest();
@@ -239,7 +239,7 @@ private class SummitEventsRegisterGuests_TEST {
             Test.setCurrentPage(pageRef);
 
             Datetime nowTime = Datetime.now();
-            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime);
+            SummitEventsShared.createEncryptedCookieWithNow('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, nowTime,true);
 
             SummitEventsRegisterGuestsController guestController = new SummitEventsRegisterGuestsController();
 

--- a/force-app/test/default/classes/SummitEventsRegister_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegister_TEST.cls
@@ -238,7 +238,7 @@ private class SummitEventsRegister_TEST {
             PageReference pageRef = Page.SummitEventsRegister;
             Test.setCurrentPage(pageRef);
             //Try to register on different instance
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
             SummitEventsRegisterController registerController = new SummitEventsRegisterController();
             //Change current registration information
             registerController.eventRegistration.Registrant_First_Name__c = 'Test2';

--- a/force-app/test/default/classes/SummitEventsRegister_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegister_TEST.cls
@@ -238,8 +238,7 @@ private class SummitEventsRegister_TEST {
             PageReference pageRef = Page.SummitEventsRegister;
             Test.setCurrentPage(pageRef);
             //Try to register on different instance
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
             SummitEventsRegisterController registerController = new SummitEventsRegisterController();
             //Change current registration information
             registerController.eventRegistration.Registrant_First_Name__c = 'Test2';

--- a/force-app/test/default/classes/SummitEventsSubmit_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsSubmit_TEST.cls
@@ -22,8 +22,7 @@ private class SummitEventsSubmit_TEST {
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -55,8 +54,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -101,8 +99,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -146,8 +143,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared SEShared = new SummitEventsShared();
-            SEShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();

--- a/force-app/test/default/classes/SummitEventsSubmit_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsSubmit_TEST.cls
@@ -22,7 +22,7 @@ private class SummitEventsSubmit_TEST {
             pageRef.getParameters().put('adminopen', 'true');
             Test.setCurrentPage(pageRef);
 
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -54,7 +54,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -99,7 +99,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();
@@ -143,7 +143,7 @@ private class SummitEventsSubmit_TEST {
             Test.startTest();
             PageReference pageRef = Page.SummitEventsSubmit;
             Test.setCurrentPage(pageRef);
-            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id);
+            SummitEventsShared.createEncryptedCookie('Transfer', seaTestInstances[1].Id, seaTestInstances[1].Event__c, seaTestRegistration.Id, true);
 
             //ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances.Id);
             SummitEventsSubmitController submitCtrl = new SummitEventsSubmitController();

--- a/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
+++ b/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
@@ -313,7 +313,7 @@ public with sharing class SummitEventsTestSharedDataFactory {
         insert testRegistration;
 
         //create encrypted string
-        String encryptedString = SummitEventsShared.createEncryptedCookie('', testRegistration.Event_Instance__c, testRegistration.Event__c, testRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', testRegistration.Event_Instance__c, testRegistration.Event__c, testRegistration.Id, true);
 
         if (encryptedString.length() > 255) {
             testRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);

--- a/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
+++ b/force-app/test/default/classes/SummitEventsTestSharedDataFactory.cls
@@ -287,9 +287,8 @@ public with sharing class SummitEventsTestSharedDataFactory {
     }
 
     public static SummitEventsRegisterGuestsController.questionData createQuestionData(String questionID, String questionValue, String questionLabel) {
-        SummitEventsShared seaShared = new SummitEventsShared();
         SummitEventsRegisterGuestsController.questionData questionData = new SummitEventsRegisterGuestsController.questionData();
-        questionData.id = seaShared.encryptString(questionID);
+        questionData.id = SummitEventsShared.encryptString(questionID);
         questionData.value = questionValue;
         questionData.question = questionLabel;
         return questionData;
@@ -314,8 +313,7 @@ public with sharing class SummitEventsTestSharedDataFactory {
         insert testRegistration;
 
         //create encrypted string
-        SummitEventsShared SEAShared = new SummitEventsShared();
-        String encryptedString = SEAShared.createEncryptedCookie('', testRegistration.Event_Instance__c, testRegistration.Event__c, testRegistration.Id);
+        String encryptedString = SummitEventsShared.createEncryptedCookie('', testRegistration.Event_Instance__c, testRegistration.Event__c, testRegistration.Id);
 
         if (encryptedString.length() > 255) {
             testRegistration.Encrypted_Registration_Id_1__c = encryptedString.substring(0, 255);

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,6 +1,7 @@
 {
   "orgName": "Summit Events Dev",
   "edition": "Developer",
+  "release": "preview",
   "features": ["Sites"],
   "settings": {
     "lightningExperienceSettings": {

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,7 +1,6 @@
 {
   "orgName": "Summit Events Dev",
   "edition": "Developer",
-  "release": "preview",
   "features": ["Sites"],
   "settings": {
     "lightningExperienceSettings": {


### PR DESCRIPTION
# Critical Changes

# Changes
- Fixed confirmation page so that if payment is received the balance shows zero
- Formula on Event Instance now shows start/stop time when close to 12
- On the guest registration if the user has entered guest information but has not added that information to the guest list a modal pops up asking "You have unsaved Guest information entered. Select Cancel to finish adding your guests." language for this pop up is configurable via new labels in the event object.
- Additional questions on the event page and on the question object now have an additional long text field for creating longer picklists. This new field can be used in addition to or to replace the old field that was a textarea with 255 characters limiting the pick list.
- Additional label fields were added to the event fee section of the event object to allow for a configurable heading if payment was received or payment was due and an opportunity to add a rich tech description underneath the heading.
- Various bug fixes

# Issues Closed
- Closes #517 
- Closes #516 
- Closes #514 
- Closes #513 
- Closes #512 
- Closes #511 
- Closes #495 
- Closes #446
- Closes #519 
