### PR TITLE
Calendar updates

### DIFF
--- a/force-app/main/default/classes/SummitEventsController.cls
+++ b/force-app/main/default/classes/SummitEventsController.cls
@@ -7,6 +7,7 @@ public with sharing class SummitEventsController {
 
     public String feedURL { get; set; }
     public String communityBaseURL { get; set; }
+    public String template { get; set; }
 
     public SummitEventsController() {
 
@@ -24,6 +25,13 @@ public with sharing class SummitEventsController {
             feedURL += namespace + '/';
         }
         feedURL += 'summiteventsfeed';
+
+        if(String.isNotBlank(ApexPages.currentPage().getParameters().get('template'))) {
+            template = ApexPages.currentPage().getParameters().get('template');
+        }
+        if(String.isBlank(template)) {
+            template = 'GeneralSLDS';
+        }
 
     }
 }

--- a/force-app/main/default/classes/SummitEventsFeed.cls
+++ b/force-app/main/default/classes/SummitEventsFeed.cls
@@ -143,25 +143,31 @@ global with sharing class SummitEventsFeed {
         ///.formatGmt('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         String formattedViewStart;
         String formattedViewEnd;
+
         if (String.isNotBlank(req.params.get('viewStart'))) {
             viewStart = Date.valueOf(String.escapeSingleQuotes(req.params.get('viewStart')));
         }
-        //if fullcalendar in use start is passed. start being protected variable
-        if (String.isNotBlank(req.params.get('start'))) {
-            viewStart = Date.valueOf(req.params.get('start'));
-        } else if (viewStart == null) {
-            viewStart = Datetime.newInstance(Date.today(), Time.newInstance(0, 0, 0, 0)).addMonths(-1);
-        }
-
         if (String.isNotBlank(req.params.get('viewEnd'))) {
             viewEnd = Date.valueOf(String.escapeSingleQuotes(req.params.get('viewEnd')));
         }
-        //if fullcalendar in use end is passed. end being protected variable
-        if (String.isNotBlank(req.params.get('end'))) {
-            viewEnd = Date.valueOf(req.params.get('end'));
-        } else if (viewEnd == null) {
-            viewEnd = Datetime.newInstance(Date.today(), Time.newInstance(0, 0, 0, 0)).addMonths(1);
 
+        //if fullcalendar in use start is passed. start being protected variable
+        if (viewStart == null) {
+            if (String.isNotBlank(req.params.get('start'))) {
+                viewStart = Date.valueOf(req.params.get('start'));
+            } else if (viewStart == null) {
+                viewStart = Datetime.newInstance(Date.today(), Time.newInstance(0, 0, 0, 0)).addMonths(-1);
+            }
+        }
+
+        //if fullcalendar in use end is passed. end being protected variable
+        if (viewEnd == null) {
+            if (String.isNotBlank(req.params.get('end'))) {
+                viewEnd = Date.valueOf(req.params.get('end'));
+            } else if (viewEnd == null) {
+                viewEnd = Datetime.newInstance(Date.today(), Time.newInstance(0, 0, 0, 0)).addMonths(1);
+
+            }
         }
 
         formattedViewStart = viewStart.format('yyyy-MM-dd');
@@ -557,7 +563,7 @@ global with sharing class SummitEventsFeed {
         }, 'Filter events on the name of an account associated to the event via the account lookup field.'));
 
         //locationtype
-        allOptions.add(makeOption('locationtype',getObjectItemList(Summit_Events__c.Location_Type__c.getDescribe()), 'Filter events on the location type set on the event or the override on an instance of the event.'));
+        allOptions.add(makeOption('locationtype', getObjectItemList(Summit_Events__c.Location_Type__c.getDescribe()), 'Filter events on the location type set on the event or the override on an instance of the event.'));
         //filter-Building
         allOptions.add(makeOption('building', getObjectItemList(Summit_Events__c.Building__c.getDescribe()), 'Filter searches with a like statement all of these items. (&building= single or coma separated list of these items)'));
 

--- a/force-app/main/default/pages/SummitEvents.page
+++ b/force-app/main/default/pages/SummitEvents.page
@@ -7,7 +7,7 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
 
 <apex:page id="SummitEvents" showHeader="false" sidebar="false" applyHtmlTag="false" applyBodyTag="false" lightningStylesheets="true" standardStylesheets="false" cache="false" docType="html-5.0" controller="SummitEventsController">
     <apex:slds />
-    <apex:composition template="GeneralSLDS">
+    <apex:composition template="{!template}">
         <apex:define name="metaPageTitle">Summit Events</apex:define>
         <apex:define name="pageTitle"><a href="/SummitEvents">Events</a></apex:define>
         <apex:define name="scriptsHead">

--- a/force-app/main/default/pages/crowncollege2020.page
+++ b/force-app/main/default/pages/crowncollege2020.page
@@ -28,7 +28,6 @@
                 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
                 <![endif]-->
                 <apex:insert name="sectionNav"/>
-                <h1>CROWN COLLEGE TEMPLATE</h1>
                 <apex:insert name="body"/>
                 <apex:insert name="footer"/>
             </div>

--- a/force-app/main/default/pages/crowncollege2020.page
+++ b/force-app/main/default/pages/crowncollege2020.page
@@ -28,6 +28,7 @@
                 <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
                 <![endif]-->
                 <apex:insert name="sectionNav"/>
+                <h1>CROWN COLLEGE TEMPLATE</h1>
                 <apex:insert name="body"/>
                 <apex:insert name="footer"/>
             </div>

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/calendar.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/calendar.js
@@ -77,10 +77,10 @@ const initCalendar = function () {
     if (audienceDD) {
         if (urlParams['audienceList']) {
             urlAudiences = urlParams['audienceList'].split(',');
-            if (urlAudiences.length === 1 || urlParams['audienceSelect'] === 'false') {
-                eraseCookie("SummitEvents");
-                audienceDD.closest('.slds-col').style.display = 'none';
-            }
+        }
+        if (urlAudiences.length === 1 || (urlParams['audienceSelect'] === 'false')) {
+            eraseCookie("SummitEvents");
+            audienceDD.closest('.slds-col').style.display = 'none';
         }
         fetch(feedURL + "?feedType=audienceDD").then((resp) => resp.json())
             .then(function (data) {
@@ -254,7 +254,7 @@ const initCalendar = function () {
                 }
             }
         }
-        if (optionCount === 1) {
+        if (optionCount === 1 || urlParams['audienceSelect'] === 'false') {
             audienceDD.closest('.slds-col').style.display = 'none';
         } else {
             urlParams['audience'] = "";

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/calendar.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/calendar.js
@@ -55,16 +55,17 @@ let eventCount = 0;
 let audienceList = [];
 
 function getSEAUrlParams() {
-    const seaParameters = ['audience', 'audienceList', 'rectype', 'viewStart', 'viewEnd', 'eventId', 'type', 'sponsor', 'displayon', 'category', 'filter', 'account', 'locationtype', 'building', 'longdesc', 'audienceSelect'];
+    const seaParameters = ['audience', 'audienceList', 'rectype', 'viewStart', 'viewEnd', 'eventId', 'type', 'sponsor', 'displayon', 'category', 'filter', 'account', 'locationtype', 'building', 'longdesc', 'audienceSelect', 'template'];
     const params = new URLSearchParams(window.location.search)
     let parameterObj = {}
+    let paramCount = 0;
     seaParameters.forEach(param => {
-        if (params.has(param)) {
-            if(param === 'viewStart' || param === 'viewstart') {
-                parameterObj['start'] = params.get(param);
-            }
-            parameterObj[param] = params.get(param);
+        //Determine if params has seaParmenter or seaParameter in lowercase and apply to paramValue or empty string
+        let paramValue = params.has(param) ? params.get(param) : params.has(param.toLowerCase()) ? params.get(param.toLowerCase()) : '';
+        if (paramValue) {
+            parameterObj[seaParameters[paramCount]] = paramValue;
         }
+        paramCount++;
     });
     parameterObj.feedType = "eventList";
     return parameterObj;
@@ -111,7 +112,7 @@ const initCalendar = function () {
         return initialView;
     }
 
-    console.log(JSON.stringify(urlParams,null,2));
+    console.log(JSON.stringify(urlParams, null, 2));
 
     const calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: getCalView(),


### PR DESCRIPTION

# Critical Changes

# Changes

- Fixed bug where url parameter 'audienceList' passed in audiences were not filtering the calendar drop down and events correctly on the Summit Events App (SEA) calendar page
     - ***audienceList***: A comma separated list of audience that will filter events to those that have those audience selected in the event multi-picklist
- Expanded url parameters to full scope of the SEA REST API Feed. These available URL parameters are:
     - ***rectype*** : filters on salesforce record type id of event records
     -  ***viewStart*** : The date scope of the feed start. (Year month day formatted 2024-03-22)
     - ***viewEnd*** : The date scope of the feed end. (Year month day formatted 2024-03-22)
     - ***eventId*** : Shows only the instances under the event umbrella of this id
     - ***type*** : Filters on "Event Type" field of the Event record (single item only)
     - ***sponsor*** : Filters on the "Event Sponsor" field of the Event record (can be a comma separated list)
     - ***displayon*** : Filters on the "Filter Where To Display" of the Event record (can be a comma separated list)
     - ***category*** : Filters on the "Filter Category" of the Event record ( can be a comma separated list)
     - ***filter*** : Searches all the fields listed in options as a like statement allowing for a broader search of location information. ( can be a comma separated list)
     - ***account*** : Filter events on the name of an account associated to the event on the "Account" field on the Event record.
     - ***locationtype*** : Filter events on the "Location Type" field on the Event record can be overrided on an instance of the event
     - ***building*** : Filter events on the Building field on the Event record. (can be a comma separated list)
     - ***longdesc*** : this will substitute the short description with the full event detail. It may not work on the calendar view.
 - Added new parameters outside of the REST API for the calendar only
     - ***audienceSelect*** : when set to false the dropdown of audience does not show.
     - ***template*** : Allows you to pass in a name of a visualforce page template you have built for SEA on your site. the .page suffix can be removed from the visualforce page name.

# Issues Closed

- Closes #554
