### PR TITLE
Fix typo in Event_Guest_Submit_List_Label__c

### DIFF
--- a/force-app/main/default/objects/Summit_Events__c/fields/Event_Guest_Submit_List_Label__c.field-meta.xml
+++ b/force-app/main/default/objects/Summit_Events__c/fields/Event_Guest_Submit_List_Label__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Event_Guest_Submit_List_Label__c</fullName>
-    <description>Appears on the submit page as title to itemized list of Guests. Defaults to &quot;Additional guests registred&quot;</description>
+    <description>Appears on the submit page as title to itemized list of Guests. Defaults to &quot;Additional guests registered&quot;</description>
     <externalId>false</externalId>
-    <inlineHelpText>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Additional guests registred&quot;</inlineHelpText>
+    <inlineHelpText>Appears on the submit page as title to itemized list of fees. Defaults to &quot;Additional guests registered&quot;</inlineHelpText>
     <label>Event Guest Submit List Label</label>
     <length>255</length>
     <required>false</required>


### PR DESCRIPTION



# Critical Changes

# Changes
- In "Event_Guest_Submit_List_Label__c.field-meta.xml" typo from "registred" to "registered".

# Issues Closed
- #565 