### PR TITLE
update regex to allow "/" to be rendered

### DIFF
--- a/force-app/main/default/classes/SummitEventsShared.cls
+++ b/force-app/main/default/classes/SummitEventsShared.cls
@@ -604,7 +604,7 @@ public with sharing class SummitEventsShared {
         splitList.addAll(sanitizePicklistString(returnSepStringList));
         splitList.addAll(sanitizePicklistString(returnSepStringList2));
         for (String p : splitList) {
-            p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-. ]', '');
+            p = p.replaceAll('[^a-zA-Z0-9@<>?&;:\\[\\]!-./ ]', '');
             if (String.isNotBlank(p)) {
                 cpl.add(new SelectOption(p, p));
             }


### PR DESCRIPTION

# Critical Changes

# Changes
- createPicklistsFromStrings is the method that removes "/" using a regex expression in SummitEventsShared class. The update is about adding "/" into the expression to ignore it. 
# Issues Closed
#530 