### PR TITLE
533 fix required appointment error

### DIFF
--- a/force-app/main/default/staticresources/SummitEventsAssets/js/loading.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/loading.js
@@ -29,7 +29,9 @@ loadReady(() => {
 
 function fadein() {
     let fadeWrapper = document.getElementById('backpage');
-    fadeWrapper.style.display = "none";
+    if(fadeWrapper){
+        fadeWrapper.style.display = "none";
+    }
     return true;
 }
 

--- a/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
+++ b/force-app/main/default/staticresources/SummitEventsAssets/js/options.js
@@ -42,8 +42,6 @@ appointmentsReady(() => {
         title.innerHTML = title.innerHTML.replace(regExDouble, '\"');
     })
 
-    populateAppJSON();
-
     //Initiate add buttons in chooser column
     if (chooser) {
         chooser.querySelectorAll(".appointmentAdd").forEach(function (appButton) {


### PR DESCRIPTION
# Critical Changes
- populateAppJSON() method in options.js now is not executed when SummitEventsRegisterAppointments vf page renders
# Changes
The issue of having the page blocked after it rendered it's because "fadein()" method was throwing an error (basically a null pointer exception). The "SummitEventsRegisterAppointments" vf page has no any element with id as "backpage" and fadein method was depended on getting at least one element to assing style.display to it. 

This is the current order of execution:
- appointmentsReady()
  - populateAppJSON()
    - checkForRequiredAppointments()
      - fadeIn() 
  - InitiationOfAddButtons()

Notes:
 - fadeIn() error was not letting InitiationOfAddButtons to execute
 - I'm calling InitiationOfAddButtons() the if block located from line 46 in options.js

There are 2 ways to fix it:
	1 - Change the order of execution where populateAppJSON() is executed after InitiationOfAddButtons()
	2 - Do not call populateAppJSON in the rendering process.

Since the expectation is not having it open when the page renders, the 2nd option fits better and the accordion will open automatically if it was missed and the user clicked next.

# Issues Closed
Closes #533 