### PR TITLE
replaced shared query with inline query for itinerary admin view

### DIFF
--- a/force-app/main/default/classes/SummitEventsGeneratedItinerariesExt.cls
+++ b/force-app/main/default/classes/SummitEventsGeneratedItinerariesExt.cls
@@ -10,7 +10,12 @@ public with sharing class SummitEventsGeneratedItinerariesExt {
 
     public SummitEventsGeneratedItinerariesExt(ApexPages.StandardController stdController) {
         seaRegistration = (Summit_Events_Registration__c) stdController.getRecord();
-        Summit_Events_Registration__c registration = SummitEventsReadShared.getRegistrationById(seaRegistration.Id);
+        Id regId = seaRegistration.Id;
+        Summit_Events_Registration__c registration = [
+                SELECT Id, Generated_Itinerary__c, Generated_Requested_Appointments__c
+                FROM Summit_Events_Registration__c
+                WHERE Id = :regId
+        ];
         generatedItinerary = registration.Generated_Itinerary__c;
         requestedItinerary = registration.Generated_Requested_Appointments__c;
     }


### PR DESCRIPTION

# Critical Changes

# Changes
- Used inline query for generated itinerary for registration record view

# Issues Closed
