### PR TITLE
Appointments auto add failing

### DIFF
--- a/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
+++ b/force-app/main/default/classes/SummitEventsAppointmentTriggerHandler.cls
@@ -246,7 +246,6 @@ public without sharing class SummitEventsAppointmentTriggerHandler {
             List<Id> uniqueRegistrationIds = new List<Id>(registrationIds);
             try {
                 appointments = Database.query(query);
-                System.debug('Found ' + appointments.size() + ' appointments');
             } catch (Exception e) {
                 System.debug(e.getMessage());
             }

--- a/force-app/main/default/classes/SummitEventsConfirmationController.cls
+++ b/force-app/main/default/classes/SummitEventsConfirmationController.cls
@@ -224,11 +224,7 @@ public with sharing class SummitEventsConfirmationController {
     public PageReference checkForPayment() {
         String errorMessage = '';
         PageReference pageRef = null;
-        List<Summit_Events_Payment__c> payments = [
-                SELECT Id, Payment_Amount__c
-                FROM Summit_Events_Payment__c
-                WHERE Event_Registration__c = :eventInformation.registrationId
-        ];
+        List<Summit_Events_Payment__c> payments = SummitEventsReadShared.getPaymentsByRegistrationId(eventInformation.registrationId);
         if (payments.size() > 0) {
             paymentReceived = true;
         } else if (payments.size() == 0) {

--- a/force-app/main/default/classes/SummitEventsReadShared.cls
+++ b/force-app/main/default/classes/SummitEventsReadShared.cls
@@ -159,6 +159,7 @@ public without sharing class SummitEventsReadShared {
                 WHERE Event_Registration__c = :registrationId
                 WITH SECURITY_ENFORCED
         ];
+
     }
 
     public static List<Summit_Events_Fee__c> getDonationsByRegistrationId(Id registrationId) {
@@ -181,6 +182,44 @@ public without sharing class SummitEventsReadShared {
                 AND Event_Fee_Type__c != 'Optional Donation'
                 AND Event_Registration__c = :registrationId
                 WITH SECURITY_ENFORCED
+        ];
+    }
+
+    public static List<Summit_Events_Appointment_Type__c> getAutoAddAppointments(Id registrationId, Id eventId, String instanceTitle, Date instanceStartDate, Date instanceEndDate, String dayOfWeek) {
+        return [
+                SELECT Id, Name, Title__c, Description__c, Appointment_Type__c, Appointment_Category__c, Registrant_Input__c, Custom_Picklist__c, Appointment_Limits__c,
+                        Chosen_State__c, Sort_Order__c, Auto_Confirm_Appointment__c, Auto_add_building__c, Auto_Add_Time__c, Do_Not_Show_Time__c
+                FROM Summit_Events_Appointment_Type__c
+                WHERE Summit_Events__c = :eventId
+                AND (Chosen_State__c = 'Added' OR Chosen_State__c = 'Added and Required' OR Chosen_State__c = 'Added but not shown')
+                AND Id NOT IN (
+                        SELECT Event_Appointment_Type__c
+                        FROM Summit_Events_Appointments__c
+                        WHERE Event_Registration__c = :registrationId
+                )
+                AND (
+                        Restrict_To_Instance_Title__r.Instance_Title__c = :instanceTitle
+                        OR Restrict_To_Instance_Title__r.Instance_Title__c = NULL
+                        OR Restrict_To_Instance_Title__r.Instance_Title__c = ''
+                )
+                AND (
+                        Date_Available_Start__c <= :instanceStartDate
+                        OR Date_Available_Start__c = NULL
+                )
+                AND (
+                        Date_Available_End__c >= :instanceEndDate
+                        OR Date_Available_End__c = NULL
+                )
+                AND (
+                        Day_of_Week_Availability__c INCLUDES (:dayOfWeek)
+                        OR Day_of_Week_Availability__c = NULL
+                )
+                AND (
+                        Appointment_Type_Status__c = 'Active'
+                        OR Appointment_Type_Status__c = NULL
+                )
+                WITH SECURITY_ENFORCED
+                ORDER BY Sort_Order__c ASC NULLS LAST
         ];
     }
 

--- a/force-app/main/default/classes/SummitEventsRegisterController.cls
+++ b/force-app/main/default/classes/SummitEventsRegisterController.cls
@@ -487,27 +487,15 @@ public with sharing class SummitEventsRegisterController {
         eventRegistration = rCRUD.updateRegistration(eventRegistration, incomingEventRegistrationId, registrantAudience, eventFeeList);
 
         String dayOfWeek = SummitEventsShared.convertDateToDatetime(evtInstance.Instance_Start_Date__c, null, '').format('EEEE');
+
         //Insert pre-chosen appointments for appointments page
-        List<Summit_Events_Appointment_Type__c> autoAddAppt = [
-                SELECT Id, Name, Title__c, Description__c, Appointment_Type__c, Appointment_Category__c, Registrant_Input__c, Custom_Picklist__c, Appointment_Limits__c,
-                        Chosen_State__c, Sort_Order__c, Auto_Confirm_Appointment__c, Auto_add_building__c, Auto_Add_Time__c, Do_Not_Show_Time__c
-                FROM Summit_Events_Appointment_Type__c
-                WHERE Summit_Events__c = :eventInformation.eventId
-                AND (Chosen_State__c = 'Added' OR Chosen_State__c = 'Added and Required' OR Chosen_State__c = 'Added but not shown')
-                AND Id NOT IN (SELECT Event_Appointment_Type__c FROM Summit_Events_Appointments__c WHERE Event_Registration__c = :eventInformation.registrationId)
-                AND (Restrict_To_Instance_Title__r.Instance_Title__c = :evtInstance.Instance_Title__c OR Restrict_To_Instance_Title__r.Instance_Title__c = NULL OR Restrict_To_Instance_Title__r.Instance_Title__c = '')
-                AND (Date_Available_Start__c <= :evtInstance.Instance_Start_Date__c OR Date_Available_Start__c = NULL)
-                AND (Date_Available_End__c >= :evtInstance.Instance_End_Date__c OR Date_Available_End__c = NULL)
-                AND (Day_of_Week_Availability__c INCLUDES (:dayOfWeek) OR Day_of_Week_Availability__c = NULL)
-                AND (Appointment_Type_Status__c = 'Active' OR Appointment_Type_Status__c = NULL)
-                ORDER BY Sort_Order__c ASC NULLS LAST
-        ];
+        List<Summit_Events_Appointment_Type__c> autoAddAppt = SummitEventsReadShared.getAutoAddAppointments(eventRegistration.Id, eventInformation.eventId, evtInstance.Instance_Title__c, evtInstance.Instance_Start_Date__c, evtInstance.Instance_End_Date__c, dayOfWeek);
 
         List<Summit_Events_Appointments__c> appointmentsToAdd = new List<Summit_Events_Appointments__c>();
         for (Summit_Events_Appointment_Type__c appt : autoAddAppt) {
             Summit_Events_Appointments__c addAppt = new Summit_Events_Appointments__c();
             addAppt.Event_Appointment_Type__c = appt.Id;
-            addAppt.Event_Registration__c = eventInformation.registrationId;
+            addAppt.Event_Registration__c = eventRegistration.Id;
             addAppt.Appointment_Title__c = appt.Title__c;
             //If appointment is not shown and auto confirmed confirm it!
             if (appt.Auto_Confirm_Appointment__c) {
@@ -595,14 +583,6 @@ public with sharing class SummitEventsRegisterController {
             SummitEventsShared.createEncryptedCookie(registrantAudience, eventRegistration.Event_Instance__c, eventRegistration.Event__c, eventRegistration.Id, true);
 
             return eventRegistration;
-        }
-
-        public void deleteFees(List<Summit_Events_Fee__c> deletableFees) {
-            try {
-                delete deletableFees;
-            } catch (Exception ex) {
-                System.debug(ex.getMessage());
-            }
         }
 
         public void insertAppointments(List<Summit_Events_Appointments__c> appointments) {

--- a/force-app/main/default/pages/SummitEventsSubmit.page
+++ b/force-app/main/default/pages/SummitEventsSubmit.page
@@ -51,8 +51,6 @@ Created by Thaddaeus Dahlberg on 5/1/2018.
                         </nav>
                     </div>
 
-                    <apex:messages layout="list" styleClass="slds-col slds-p-around_x-small slds-size_1-of-1 slds-notify slds-notify_toast slds-theme_warning"/>
-
                     <apex:outputPanel rendered="{!eventIsClosed}" layout="block" styleClass="slds-col slds-size_1-of-1 slds-p-vertical_x-small slds-p-vertical_xx-small regularLists">
                         <h2 class="slds-text-heading_large slds-p-vertical_xx-small">
                             <apex:outputText value="{!eventPage.Event_Submit_Title__c}"/>

--- a/force-app/test/default/classes/SummitEventsRegister_TEST.cls
+++ b/force-app/test/default/classes/SummitEventsRegister_TEST.cls
@@ -25,6 +25,7 @@ private class SummitEventsRegister_TEST {
             System.assert(registerController.getApplicantTypeDD().size() > 0);
             System.assert(registerController.getRelationshipDD().size() > 0);
             System.assert(registerController.getPronounDD().size() > 0);
+            System.assert(registerController.getAccessibilityDD().size() > 0);
             System.assertEquals(registerController.checkEventDetails(), null);
             registerController.eventRegistration.Registrant_First_Name__c = 'Test';
             registerController.eventRegistration.Registrant_Last_Name__c = 'Tester';
@@ -162,6 +163,35 @@ private class SummitEventsRegister_TEST {
             ];
             //There should be only one registration, the first one inserted as data. The second should have been restricted and not allowed through
             System.assertEquals(registrations.size(), 1);
+            Test.stopTest();
+        }
+    }
+
+
+    @IsTest static void testEventWithAutoAddAppointments() {
+        List<Summit_Events_Instance__c> seaTestInstances = SummitEventsTestSharedDataFactory.createTestEvent();
+        Summit_Events__c seaTestEvent = SummitEventsTestSharedDataFactory.getEventRecord(seaTestInstances[1].Event__c);
+        List<Summit_Events_Appointment_Type__c> testAppointmentTypes = SummitEventsTestSharedDataFactory.createAppointmentTypes(seaTestInstances[1].Event__c);
+        testAppointmentTypes[0].Chosen_State__c = 'Added but not shown';
+        testAppointmentTypes[1].Chosen_State__c = 'Added and Required';
+        testAppointmentTypes[2].Chosen_State__c = 'Added';
+        update testAppointmentTypes;
+        User testUser = SummitEventsTestSharedDataFactory.userToRunWith('Standard User','Summit_Events_Registrant');
+        System.runAs(testUser) {
+            Test.startTest();
+            PageReference pageRef = Page.SummitEventsRegister;
+            Test.setCurrentPage(pageRef);
+            ApexPages.currentPage().getParameters().put('instanceID', seaTestInstances[1].Id);
+            SummitEventsRegisterController registerController = new SummitEventsRegisterController();
+            registerController.eventRegistration.Registrant_First_Name__c = 'Test';
+            registerController.eventRegistration.Registrant_Last_Name__c = 'Tester';
+            registerController.eventRegistration.Registrant_Email__c = 'test@test.net';
+            registerController.saveContactRegistration();
+            List<Summit_EVents_Appointments__c> appointments = [
+                    SELECT Id FROM Summit_Events_Appointments__c WHERE Event_Registration__c = :registerController.eventRegistration.Id
+            ];
+            //There should be only one registration, the first one inserted as data. The second should have been restricted and not allowed through
+            System.assertEquals(appointments.size(), 3);
             Test.stopTest();
         }
     }


### PR DESCRIPTION
# Critical Changes

# Changes
- Moved payment query when returning from payment gateway to shared read query. Payments were not completing upon return to SEA because payment record code not be found.
- Moved auto add appointment query to shared read queries. 'Added', 'Added but not shown', and 'Added and required' appointment types were not receipting correctly as appointments.
- Fixed reg id assignment to appointments
- Added unit test to cover auto added appointments

# Issues Closed
